### PR TITLE
Character controller improvements

### DIFF
--- a/.idea/runConfigurations/Run__debug_.xml
+++ b/.idea/runConfigurations/Run__debug_.xml
@@ -9,7 +9,9 @@
     <option name="withSudo" value="false" />
     <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
-    <envs />
+    <envs>
+      <env name="RUSTFLAGS" value="-Zthreads=16" />
+    </envs>
     <option name="isRedirectInput" value="false" />
     <option name="redirectInputPath" value="" />
     <method v="2" />

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -4161,7 +4161,6 @@ dependencies = [
  "noise",
  "num-traits",
  "ordered-float",
- "petgraph",
  "rapier3d",
  "ron",
  "serde",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -78,13 +78,12 @@ bevy_common_assets = { version = "0.8.0", features = ["ron"] }
 array-init = "2.1.0"
 bevy_pkv = "0.9.0" # settings
 crossbeam = "0.8.2"
-fixedbitset = "0.4.2" # petgraph edge storage
+fixedbitset = "0.4.2" # navigation graph edge storage
 futures-lite = "2.1.0" # especially for `yield_now()`
 nanorand = { version = "0.7.0", default-features = false, features = ["std", "wyrand", "getrandom"] } # wasm is broken without std and getrandom
 noise = "0.8.2"
 num-traits = "0.2.17"
 ordered-float = "4.2.0"
-petgraph = { version = "0.6.4", default-features = false } # pathfinding
 ron = "0.8.1"
 static_assertions = "1.1.0"
 serde = "1"
@@ -118,7 +117,6 @@ nanorand = { workspace = true }
 noise = { workspace = true }
 num-traits = { workspace = true }
 ordered-float = { workspace = true }
-petgraph = { workspace = true }
 ron = { workspace = true }
 static_assertions = { workspace = true }
 serde = { workspace = true }

--- a/rs/assets/pickups/pickup_material.mat.ron
+++ b/rs/assets/pickups/pickup_material.mat.ron
@@ -1,6 +1,6 @@
 ExtendedMaterial(
 	extension: BubbleMaterial(
-		glow_color: Rgba ( red: 4.0, green: 1.0, blue: 0.0, alpha: 0.15 ),
+		glow_color: Rgba ( red: 4.0, green: 1.0, blue: 0.0, alpha: 0.12 ),
 	),
 	base: StandardMaterial(
 		specular_transmission: 1.0,

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -1,21 +1,25 @@
+#![cfg_attr(
+all(not(debug_assertions), target_os = "windows"),
+windows_subsystem = "windows"
+)]
+
 use crate::mats::BubbleMaterial;
 use bevy::{
 	diagnostic::FrameTimeDiagnosticsPlugin, pbr::ExtendedMaterial, prelude::*,
 	render::RenderPlugin, window::PrimaryWindow,
 };
-use bevy_common_assets::ron::RonAssetPlugin;
 use bevy_kira_audio::AudioPlugin;
 use bevy_pkv::PkvStore;
 use bevy_rapier3d::prelude::*;
 use particles::ParticlesPlugin;
 use player::ctrl::CtrlVel;
 use std::{f32::consts::*, fmt::Debug, time::Duration};
-use util::IntoFnPlugin;
-use util::RonReflectAssetLoader;
+use util::{IntoFnPlugin, RonReflectAssetLoader};
 
 #[allow(unused_imports, clippy::single_component_path_imports)]
 #[cfg(all(debug_assertions, not(target_arch = "wasm32")))]
 use bevy_dylib;
+use bevy_rapier3d::plugin::PhysicsSet::StepSimulation;
 
 pub mod enemies;
 pub mod mats;
@@ -33,9 +37,9 @@ pub mod util;
 /// Epsilon
 pub const EPS: f32 = 1.0e-5;
 /// Rotational epsilon in radians
-pub const R_EPS: f32 = TAU / (360.0 * 4.0);
+pub const R_EPS: f32 = TAU / 360.0; // 1 degree
 /// Fixed delta time
-pub const DT: f32 = 1.0 / 128.0;
+pub const DT: f32 = 1.0 / 30.0;
 /// Up vector
 pub const UP: Vect = Vect::Z;
 
@@ -115,7 +119,7 @@ pub fn game_plugin(app: &mut App) -> &mut App {
 		MaterialPlugin::<ExtendedMaterial<StandardMaterial, BubbleMaterial>>::default(),
 	))
 	.add_systems(Startup, startup)
-	.add_systems(Update, (terminal_velocity, fullscreen))
+	.add_systems(Update, (terminal_velocity.before(StepSimulation), fullscreen))
 	.add_systems(PostUpdate, (despawn_oob,));
 	type BubbleMatExt = ExtendedMaterial<StandardMaterial, BubbleMaterial>;
 	let registry = app.world.get_resource::<AppTypeRegistry>().unwrap().clone();
@@ -124,7 +128,10 @@ pub fn game_plugin(app: &mut App) -> &mut App {
 		reg.register::<BubbleMaterial>();
 		reg.register::<BubbleMatExt>();
 	}
-	app.register_asset_loader(RonReflectAssetLoader::<BubbleMatExt>::new(registry, vec!["mat.ron"]));
+	app.register_asset_loader(RonReflectAssetLoader::<BubbleMatExt>::new(
+		registry,
+		vec!["mat.ron"],
+	));
 	app
 }
 

--- a/rs/src/nav.rs
+++ b/rs/src/nav.rs
@@ -1,14 +1,110 @@
-use bevy::prelude::*;
-use fixedbitset::FixedBitSet;
-use petgraph::visit::{
-	Data, EdgeRef, GraphBase, GraphRef, IntoEdgeReferences, IntoEdges, IntoNeighbors, Visitable,
+use crate::{
+	nav::{alg::AStar, heightmap::TriId},
+	planet::chunks::ChunkIndex,
+	util::Todo,
 };
+use bevy::{prelude::*, utils::HashMap};
 use rapier3d::prelude::*;
-use std::{f32::consts::SQRT_2, ops::Range};
+use std::{collections::HashSet, sync::Weak};
 
+pub mod alg;
+pub mod heightmap;
+
+#[derive(Resource, Debug)]
 pub struct NavGraph {
-	_chunks: Vec<NavChunk>,
-	_seams: Vec<Seam>,
+	heightmaps: HashMap<ChunkIndex, Weak<HeightField>>,
+	structures: HashMap<Todo, Weak<Todo>>,
+	islands: HashMap<Todo, Weak<Todo>>,
+	heightmap_structure_seams: HashMap<Todo, Todo>, // should probably be bi-directional map
+	island_structure_seams: HashMap<Todo, Todo>,    // should probably be bi-directional map
+}
+
+/// ID of a triangle in the world by chunk index and triangle index within that chunk.
+#[derive(Default, Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct PlanetTri {
+	pub chunk: ChunkIndex,
+	pub tri: TriId,
+}
+
+#[derive(Copy, Clone, Debug, Deref)]
+pub struct NavGraphRef<'a, EdgeGen> {
+	#[deref]
+	graph: &'a NavGraph,
+	edge_generator: EdgeGen,
+}
+
+impl<'a, EdgeGen: EdgeVendor> NavGraphRef<'a, EdgeGen> {
+	pub fn new(graph: &'a NavGraph, edge_generator: EdgeGen) -> Self {
+		Self {
+			graph,
+			edge_generator,
+		}
+	}
+}
+
+impl<'a, EdgeGen: EdgeVendor + Copy + 'static> NavGraphRef<'a, EdgeGen> {
+	fn edges(self, a: NavIdx) -> impl Iterator<Item = NavEdge> + 'a + 'static {
+		let Self {
+			graph,
+			edge_generator,
+			..
+		} = self;
+		let iter = edge_generator.find_edges(graph, a);
+		iter
+	}
+
+	pub fn neighbors(self, a: NavIdx) -> impl Iterator<Item = NavIdx> + 'a + 'static {
+		let Self {
+			graph,
+			edge_generator,
+		} = self;
+		let iter = edge_generator.find_edges(graph, a);
+		iter.map(move |edge| match edge {
+			NavEdge::GroundToGround { target, .. } => NavIdx::Ground(target),
+			NavEdge::StructureToStructure { target, .. } => NavIdx::Structure(target),
+			NavEdge::GroundToStructure { target, .. } => NavIdx::Structure(target),
+			NavEdge::StructureToGround { target, .. } => NavIdx::Ground(target),
+		})
+	}
+
+	// PERF: may want custom set of FixedBitSets for different nodes, rather than huge HashSet
+	pub fn visit_map(self: &Self) -> HashSet<NavIdx> {
+		HashSet::new()
+	}
+
+	pub fn reset_map(self: &Self, map: &mut HashSet<NavIdx>) {
+		map.clear()
+	}
+}
+
+// impl<'a, EdgGen: Copy> IntoEdgeReferences for NavGraphRef<'a, EdgGen> {
+// 	type EdgeRef = NavEdge;
+// 	type EdgeReferences = EdgeRefs;
+//
+// 	fn edge_references(self) -> Self::EdgeReferences {
+// 		EdgeRefs
+// 	}
+// }
+//
+// pub struct EdgeRefs;
+//
+// impl Iterator for EdgeRefs {
+// 	type Item = NavEdge;
+//
+// 	fn next(&mut self) -> Option<Self::Item> {
+// 		todo!()
+// 	}
+// }
+
+impl<'a, EdgeGen: EdgeVendor + Copy + 'static> NavGraphRef<'a, EdgeGen> {
+	pub async fn astar(
+		self,
+		start: NavIdx,
+		goal: NavIdx,
+		edge_cost: impl FnMut(NavEdge) -> f32,
+	) -> Option<(f32, Vec<NavIdx>)> {
+		AStar::new(self.edge_generator, edge_cost).run(self.graph, start, goal)
+	}
 }
 
 pub struct NavMesh {
@@ -20,340 +116,82 @@ pub struct NavVolume {
 	_shape: TypedShape<'static>,
 }
 
-pub enum NavChunk {
-	Mesh(NavMesh),
-	Volume(NavVolume),
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum NavIdx {
+	Ground(PlanetTri),
+	Structure(Todo),
 }
 
-pub struct Seam {}
-
-#[derive(Copy, Clone, Deref)]
-pub struct HeightmapNavGraph<'a, F: FnMut(TriPair) -> bool + Copy> {
-	#[deref]
-	heights: &'a HeightField,
-	filter: F,
-}
-
-impl<'a, F: FnMut(TriPair) -> bool + Copy> HeightmapNavGraph<'a, F> {
-	pub fn new(heights: &'a HeightField, filter: F) -> Self {
-		Self { heights, filter }
-	}
-
-	pub fn astar(
+/// A trait for functions that provide edges for `NavGraph::into_edges` without creating work for
+/// the pathfinding algorithm for edges that a given entity will never be able to traverse.
+///
+/// This is basically a trait alias for a complicated `FnMut` bound.
+pub trait EdgeVendor {
+	fn find_edges<'a>(
 		self,
-		start: <Self as GraphBase>::NodeId,
-		goal: <Self as GraphBase>::NodeId,
-		edge_cost: impl FnMut(TriPair) -> f32,
-	) -> Option<(f32, Vec<<Self as GraphBase>::NodeId>)> {
-		petgraph::algo::astar(
-			self,
-			start,
-			|id| id == goal,
-			edge_cost,
-			|id| {
-				// // Manhattan distance
-				// let (i, j, left) = self.split_triangle_id(id);
-				// let (gi, gj, gleft) = self.split_triangle_id(goal);
-				// let left = !left as usize; // treat left as 0 and right as 1
-				// let gleft = !gleft as usize;
-				// ((gi * 2 + gleft).abs_diff(i * 2 + left)
-				// 	+ (gj * 2 + gleft).abs_diff(j * 2 + left))
-				// 	as f32
+		graph: &'a NavGraph,
+		node: NavIdx,
+	) -> impl Iterator<Item = NavEdge> + 'a + 'static;
+}
 
-				// Euclidian distance
-				let goal = self.triangle_at_id(goal).unwrap().center();
-				let center = self.triangle_at_id(id).unwrap().center();
-				Vec3::from(goal).distance(Vec3::from(center))
-			},
-		)
+pub struct SumEdges<A, B> {
+	pub a: A,
+	pub b: B,
+}
+
+impl<A: EdgeVendor, B: EdgeVendor> EdgeVendor for SumEdges<A, B> {
+	fn find_edges<'a>(
+		self,
+		graph: &'a NavGraph,
+		node: NavIdx,
+	) -> impl Iterator<Item = NavEdge> + 'a + 'static {
+		self.a
+			.find_edges(graph, node)
+			.chain(self.b.find_edges(graph, node))
 	}
 }
 
-pub fn height_field_graph_with_max_climb(
-	heights: &HeightField,
-	max_climb_radians: f32,
-) -> HeightmapNavGraph<impl FnMut(TriPair) -> bool + Copy + '_> {
-	HeightmapNavGraph {
-		heights,
-		filter: move |pair: TriPair| {
-			let (si, sj, sl) = heights.split_triangle_id(pair.source());
-			let (ti, tj, _tl) = heights.split_triangle_id(pair.target());
-			let (si, sj, ti, tj) = (si as f32, sj as f32, ti as f32, tj as f32);
-			let dir = if si == ti && sj == tj {
-				// same cell, towards other triangle
-				if sl {
-					Vec3::new(SQRT_2, 0.0, SQRT_2)
-				} else {
-					Vec3::new(-SQRT_2, 0.0, -SQRT_2)
-				}
-			} else {
-				Vec3::new(tj - sj, 0.0, ti - si).normalize()
-			};
-			let snorm = heights
-				.triangle_at_id(pair.source())
-				.unwrap()
-				.normal()
-				.unwrap();
-			if snorm.angle(&Vec3::Y.into()) > max_climb_radians {
-				// Already on a steep slope
-				let dot = dir.dot(snorm.into());
-				if dot < 0.0 {
-					// Against normal -- Uphill
-					false
-				} else {
-					// With normal -- Downhill
-					true
-				}
-			} else {
-				// Not on steep slope, check slope of target
-				let tnorm = heights
-					.triangle_at_id(pair.target())
-					.unwrap()
-					.normal()
-					.unwrap();
-				let dot = dir.dot(tnorm.into());
-				if dot < 0.0 {
-					// Against normal, so uphill
-					tnorm.angle(&Vec3::Y.into()) <= max_climb_radians
-				} else {
-					// Normal is pointing away from us, so downhill
-					true
-				}
-			}
-		},
+pub trait CombineVendors: EdgeVendor {
+	fn plus<Other: EdgeVendor>(self, next: Other) -> impl EdgeVendor;
+}
+
+impl<T: EdgeVendor> CombineVendors for T {
+	fn plus<Other: EdgeVendor>(self, next: Other) -> impl EdgeVendor {
+		SumEdges { a: self, b: next }
 	}
 }
-
-pub trait FnsThatShouldBePub {
-	fn num_triangles(&self) -> usize;
-
-	fn split_triangle_id(&self, id: u32) -> (usize, usize, bool);
-
-	fn triangle_id(&self, i: usize, j: usize, left: bool) -> u32;
-}
-
-impl FnsThatShouldBePub for HeightField {
-	fn num_triangles(&self) -> usize {
-		self.nrows() * self.ncols() * 2
-	}
-
-	fn split_triangle_id(&self, id: u32) -> (usize, usize, bool) {
-		let left = id < self.num_triangles() as u32 / 2;
-		let cell_id = if left {
-			id as usize
-		} else {
-			id as usize - self.num_triangles() / 2
-		};
-		let j = cell_id / self.nrows();
-		let i = cell_id - j * self.nrows();
-		(i, j, left)
-	}
-
-	fn triangle_id(&self, i: usize, j: usize, left: bool) -> u32 {
-		let tid = j * self.nrows() + i;
-		if left {
-			tid as u32
-		} else {
-			(tid + self.num_triangles() / 2) as u32
-		}
-	}
-}
-
-impl<F: FnMut(TriPair) -> bool + Copy> GraphBase for HeightmapNavGraph<'_, F> {
-	type EdgeId = TriPair;
-	type NodeId = TriId;
-}
-
-impl<F: FnMut(TriPair) -> bool + Copy> Visitable for HeightmapNavGraph<'_, F> {
-	type Map = FixedBitSet;
-
-	fn visit_map(&self) -> Self::Map {
-		FixedBitSet::with_capacity(self.heights.nrows() * self.heights.ncols())
-	}
-
-	fn reset_map(&self, map: &mut Self::Map) {
-		if map.len() != self.heights.nrows() * self.heights.nrows() {
-			*map = FixedBitSet::with_capacity(self.heights.nrows() * self.heights.ncols())
-		} else {
-			map.clear()
-		}
-	}
-}
-
-impl<'a, F: FnMut(TriPair) -> bool + Copy> IntoEdgeReferences for HeightmapNavGraph<'a, F> {
-	type EdgeRef = TriPair;
-	type EdgeReferences = EdgeIter<'a, F>;
-
-	fn edge_references(self) -> Self::EdgeReferences {
-		EdgeIter::new(self)
-	}
-}
-
-pub struct EdgeIter<'a, F: FnMut(TriPair) -> bool + Copy> {
-	graph: HeightmapNavGraph<'a, F>,
-	range: Range<TriId>,
-	curr_edges: Option<<Vec<TriPair> as IntoIterator>::IntoIter>,
-}
-
-impl<'a, F: FnMut(TriPair) -> bool + Copy> EdgeIter<'a, F> {
-	fn new(data: HeightmapNavGraph<'a, F>) -> Self {
-		let range = 0..data.num_triangles() as u32;
-		Self {
-			graph: data,
-			range,
-			curr_edges: None,
-		}
-	}
-}
-
-impl<F: FnMut(TriPair) -> bool + Copy> Iterator for EdgeIter<'_, F> {
-	type Item = TriPair;
-
-	fn next(&mut self) -> Option<Self::Item> {
-		loop {
-			if let Some(mut curr) = self.curr_edges.take() {
-				if let Some(pair) = curr.next() {
-					return Some(pair);
-				} else {
-					self.curr_edges = self.range.next().map(|id| self.graph.edges(id));
-				}
-			} else {
-				return None;
-			}
-		}
-	}
-}
-
-impl<F: FnMut(TriPair) -> bool + Copy> Data for HeightmapNavGraph<'_, F> {
-	type NodeWeight = Vec3; // normal
-	type EdgeWeight = ();
-}
-
-impl<F: FnMut(TriPair) -> bool + Copy> GraphRef for HeightmapNavGraph<'_, F> {}
-
-impl<F: FnMut(TriPair) -> bool + Copy> IntoNeighbors for HeightmapNavGraph<'_, F> {
-	type Neighbors = <Vec<TriId> as IntoIterator>::IntoIter;
-
-	fn neighbors(mut self, a: Self::NodeId) -> Self::Neighbors {
-		//TODO: Create special iterator instead of allocating vecs
-		let (i, j, left) = self.split_triangle_id(a);
-		let mut neighbors = Vec::new();
-
-		let mut try_push = |this: &mut Self, target| {
-			if (this.filter)(TriPair::new(a, target)) {
-				neighbors.push(target);
-			}
-		};
-
-		if left {
-			let right = self.triangle_id(i, j, false);
-			(try_push)(&mut self, right);
-
-			if i > 0 {
-				let up = self.triangle_id(i - 1, j, false);
-				(try_push)(&mut self, up);
-			}
-
-			if j > 0 {
-				let left = self.triangle_id(i, j - 1, false);
-				(try_push)(&mut self, left);
-			}
-		} else {
-			let left = self.triangle_id(i, j, true);
-			(try_push)(&mut self, left);
-
-			if j < self.heights.ncols() - 1 {
-				let right = self.triangle_id(i, j + 1, true);
-				(try_push)(&mut self, right);
-			}
-
-			if i < self.heights.nrows() - 1 {
-				let down = self.triangle_id(i + 1, j, true);
-				(try_push)(&mut self, down);
-			}
-		}
-		neighbors.into_iter()
-	}
-}
-
-impl<F: FnMut(TriPair) -> bool + Copy> IntoEdges for HeightmapNavGraph<'_, F> {
-	type Edges = <Vec<TriPair> as IntoIterator>::IntoIter;
-
-	fn edges(mut self, a: Self::NodeId) -> Self::Edges {
-		//TODO: Create special iterator instead of allocating vecs
-		let mut edges = Vec::new();
-		let (i, j, left) = self.split_triangle_id(a);
-
-		let mut try_push = |this: &mut Self, target| {
-			let pair = TriPair::new(a, target);
-			if (this.filter)(pair) {
-				edges.push(pair);
-			}
-		};
-
-		if left {
-			let right = self.triangle_id(i, j, false);
-			(try_push)(&mut self, right);
-
-			if i > 0 {
-				let up = self.triangle_id(i - 1, j, false);
-				(try_push)(&mut self, up);
-			}
-
-			if j > 0 {
-				let left = self.triangle_id(i, j - 1, false);
-				(try_push)(&mut self, left);
-			}
-		} else {
-			let left = self.triangle_id(i, j, true);
-			(try_push)(&mut self, left);
-
-			if j < self.heights.ncols() - 1 {
-				let right = self.triangle_id(i, j + 1, true);
-				(try_push)(&mut self, right);
-			}
-
-			if i < self.heights.nrows() - 1 {
-				let down = self.triangle_id(i + 1, j, true);
-				(try_push)(&mut self, down);
-			}
-		}
-		edges.into_iter()
-	}
-}
-
-type TriId = u32;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct TriPair {
-	source: TriId,
-	target: TriId,
+pub enum NavEdge {
+	GroundToGround {
+		source: PlanetTri,
+		target: PlanetTri,
+	},
+	StructureToStructure {
+		source: Todo,
+		target: Todo,
+	},
+	GroundToStructure {
+		source: PlanetTri,
+		target: Todo,
+	},
+	StructureToGround {
+		source: Todo,
+		target: PlanetTri,
+	},
 }
 
-impl TriPair {
-	fn new(source: TriId, target: TriId) -> Self {
-		Self { source, target }
+impl NavEdge {
+	pub fn target(self) -> NavIdx {
+		match self {
+			NavEdge::GroundToGround { target, .. } => NavIdx::Ground(target),
+			NavEdge::StructureToStructure { target, .. } => NavIdx::Structure(target),
+			NavEdge::GroundToStructure { target, .. } => NavIdx::Structure(target),
+			NavEdge::StructureToGround { target, .. } => NavIdx::Ground(target),
+		}
 	}
 }
 
-impl EdgeRef for TriPair {
-	type NodeId = TriId;
-	type EdgeId = Self;
-	type Weight = ();
-
-	fn source(&self) -> Self::NodeId {
-		self.source
-	}
-
-	fn target(&self) -> Self::NodeId {
-		self.target
-	}
-
-	fn weight(&self) -> &Self::Weight {
-		&()
-	}
-
-	fn id(&self) -> Self::EdgeId {
-		*self
-	}
+pub trait NavEdgeFilter {
+	fn test(&mut self, edge: NavEdge) -> bool;
 }

--- a/rs/src/nav/alg.rs
+++ b/rs/src/nav/alg.rs
@@ -1,0 +1,219 @@
+use bevy::{math::Vec3, prelude::default};
+use std::{
+	cmp::Ordering,
+	collections::{
+		hash_map::Entry::{Occupied, Vacant},
+		BinaryHeap, HashMap,
+	},
+	sync::Weak,
+};
+
+use crate::nav::{
+	EdgeVendor, NavEdge, NavGraph, NavGraphRef, NavIdx,
+	NavIdx::{Ground, Structure},
+};
+
+#[derive(Default)]
+pub struct PathTracker {
+	pub came_from: HashMap<NavIdx, NavIdx>,
+}
+
+impl PathTracker {
+	pub fn new() -> PathTracker {
+		PathTracker {
+			came_from: HashMap::new(),
+		}
+	}
+
+	fn set_predecessor(&mut self, node: NavIdx, previous: NavIdx) {
+		self.came_from.insert(node, previous);
+	}
+
+	fn reconstruct_path_to(&self, last: NavIdx) -> Vec<NavIdx> {
+		let mut path = vec![last];
+
+		let mut current = last;
+		while let Some(&previous) = self.came_from.get(&current) {
+			path.push(previous);
+			current = previous;
+		}
+
+		path.reverse();
+
+		path
+	}
+}
+
+#[derive(Default)]
+pub struct AStar<Cost, EdgeGen>
+where
+	EdgeGen: EdgeVendor + Copy + 'static,
+	Cost: FnMut(NavEdge) -> f32,
+{
+	edge_generator: EdgeGen,
+	visit_next: BinaryHeap<MinScored>,
+	scores: HashMap<NavIdx, f32>,
+	estimate_scores: HashMap<NavIdx, f32>,
+	path_tracker: PathTracker,
+	edge_cost: Cost,
+}
+
+impl<Cost, EdgeGen> AStar<Cost, EdgeGen>
+where
+	EdgeGen: EdgeVendor + Copy + 'static,
+	Cost: FnMut(NavEdge) -> f32,
+{
+	pub fn new(edge_generator: EdgeGen, edge_cost: Cost) -> Self {
+		Self {
+			edge_generator,
+			visit_next: default(),
+			scores: default(),
+			estimate_scores: default(),
+			path_tracker: default(),
+			edge_cost,
+		}
+	}
+	pub fn run(
+		&mut self,
+		graph: &NavGraph,
+		start: NavIdx,
+		goal: NavIdx,
+	) -> Option<(f32, Vec<NavIdx>)>
+	where
+		Cost: FnMut(NavEdge) -> f32,
+	{
+		let Self {
+			edge_generator,
+			visit_next,
+			scores,
+			estimate_scores,
+			path_tracker,
+			edge_cost,
+		} = self;
+
+		let graph = NavGraphRef {
+			graph,
+			edge_generator: *edge_generator,
+		};
+
+		let estimate_cost = |id| match (id, goal) {
+			(Ground(start), Ground(end)) => {
+				let Some((start_hm, end_hm)) = graph
+					.heightmaps
+					.get(&start.chunk)
+					.and_then(Weak::upgrade)
+					.zip(graph.heightmaps.get(&end.chunk).and_then(Weak::upgrade))
+				else {
+					return f32::INFINITY;
+				};
+				let Some((start, end)) = start_hm
+					.triangle_at_id(start.tri)
+					.zip(end_hm.triangle_at_id(end.tri))
+				else {
+					return f32::INFINITY;
+				};
+				Vec3::from(start.center()).distance(Vec3::from(end.center()))
+			}
+			(Ground(_tri), Structure(_)) => todo!(),
+			(Structure(_), Ground(_tri)) => todo!(),
+			(Structure(_), Structure(_)) => todo!(),
+		};
+
+		path_tracker.came_from.clear();
+		scores.insert(start, 0.0);
+		visit_next.push(MinScored(estimate_cost(start), start));
+
+		while let Some(MinScored(estimate_score, node)) = visit_next.pop() {
+			if node == goal {
+				let path = path_tracker.reconstruct_path_to(node);
+				let cost = scores[&node];
+				return Some((cost, path));
+			}
+
+			// This lookup can be unwrapped without fear of panic since the node was necessarily scored
+			// before adding it to `visit_next`.
+			let node_score = scores[&node];
+
+			match estimate_scores.entry(node) {
+				Occupied(mut entry) => {
+					// If the node has already been visited with an equal or lower score than now, then
+					// we do not need to re-visit it.
+					if *entry.get() <= estimate_score {
+						continue;
+					}
+					entry.insert(estimate_score);
+				}
+				Vacant(entry) => {
+					entry.insert(estimate_score);
+				}
+			}
+
+			for edge in graph.edges(node) {
+				let next = edge.target();
+				let next_score = node_score + edge_cost(edge);
+
+				match scores.entry(next) {
+					Occupied(mut entry) => {
+						// No need to add neighbors that we have already reached through a shorter path
+						// than now.
+						if *entry.get() <= next_score {
+							continue;
+						}
+						entry.insert(next_score);
+					}
+					Vacant(entry) => {
+						entry.insert(next_score);
+					}
+				}
+
+				path_tracker.set_predecessor(next, node);
+				let next_estimate_score = next_score + estimate_cost(next);
+				visit_next.push(MinScored(next_estimate_score, next));
+			}
+		}
+
+		None
+	}
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct MinScored(pub f32, pub NavIdx);
+
+impl PartialEq for MinScored {
+	#[inline]
+	fn eq(&self, other: &MinScored) -> bool {
+		self.cmp(other) == Ordering::Equal
+	}
+}
+
+impl Eq for MinScored {}
+
+impl PartialOrd for MinScored {
+	#[inline]
+	fn partial_cmp(&self, other: &MinScored) -> Option<Ordering> {
+		Some(self.cmp(other))
+	}
+}
+
+impl Ord for MinScored {
+	#[inline]
+	fn cmp(&self, other: &MinScored) -> Ordering {
+		let a = &self.0;
+		let b = &other.0;
+		if a == b {
+			Ordering::Equal
+		} else if a < b {
+			Ordering::Greater
+		} else if a > b {
+			Ordering::Less
+		} else if a.ne(a) && b.ne(b) {
+			// these are the NaN cases
+			Ordering::Equal
+		} else if a.ne(a) {
+			// Order NaN less, so that it is last in the MinScore order
+			Ordering::Less
+		} else {
+			Ordering::Greater
+		}
+	}
+}

--- a/rs/src/nav/heightmap.rs
+++ b/rs/src/nav/heightmap.rs
@@ -1,0 +1,381 @@
+use super::{EdgeVendor, NavEdge, NavEdgeFilter, NavGraph, NavIdx, PlanetTri};
+use crate::planet::chunks::{ChunkIndex, CHUNK_COLS, CHUNK_ROWS};
+use bevy::{prelude::*, utils::HashMap};
+use rapier3d::geometry::HeightField;
+use std::{f32::consts::SQRT_2, sync::Weak};
+
+pub trait FnsThatShouldBePub {
+	fn num_triangles(&self) -> usize;
+
+	fn split_triangle_id(&self, id: u32) -> (usize, usize, bool);
+
+	fn triangle_id(&self, i: usize, j: usize, left: bool) -> u32;
+}
+
+impl FnsThatShouldBePub for HeightField {
+	fn num_triangles(&self) -> usize {
+		num_tris(self.nrows(), self.ncols())
+	}
+
+	fn split_triangle_id(&self, id: u32) -> (usize, usize, bool) {
+		split_triangle_id(self.nrows(), self.ncols(), id)
+	}
+
+	fn triangle_id(&self, i: usize, j: usize, left: bool) -> u32 {
+		tri_id(self.nrows(), self.ncols(), i, j, left)
+	}
+}
+
+/// Triangle index within a specific chunk's `HeightField`.
+pub type TriId = u32;
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct TriPair {
+	pub source: TriId,
+	pub target: TriId,
+}
+
+impl TriPair {
+	pub fn new(source: TriId, target: TriId) -> Self {
+		Self { source, target }
+	}
+}
+
+pub const fn num_tris(nrows: usize, ncols: usize) -> usize {
+	nrows * ncols * 2
+}
+
+pub const fn split_triangle_id(nrows: usize, ncols: usize, id: TriId) -> (usize, usize, bool) {
+	let num_tris = num_tris(nrows, ncols);
+	let left = id < num_tris as u32 / 2;
+	let cell_id = if left {
+		id as usize
+	} else {
+		id as usize - (nrows * ncols)
+	};
+	let j = cell_id / nrows;
+	let i = cell_id - j * nrows;
+	(i, j, left)
+}
+
+pub const fn tri_id(nrows: usize, ncols: usize, i: usize, j: usize, left: bool) -> TriId {
+	let tid = j * nrows + i;
+	if left {
+		tid as u32
+	} else {
+		(tid + num_tris(nrows, ncols) / 2) as u32
+	}
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct GroundEdges<F: NavEdgeFilter + Clone + 'static> {
+	filter: F,
+}
+
+impl<F: NavEdgeFilter + Clone> EdgeVendor for GroundEdges<F> {
+	fn find_edges<'a>(
+		self,
+		graph: &'a NavGraph,
+		node: NavIdx,
+	) -> impl Iterator<Item = NavEdge> + 'static {
+		match node {
+			NavIdx::Ground(id) => graph
+				.heightmaps
+				.get(&id.chunk)
+				.and_then(Weak::upgrade)
+				.map_or_else(
+					|| GroundTriEdgeIter::none(self.filter.clone()),
+					|heights| {
+						GroundTriEdgeIter::new(
+							heights.nrows(),
+							heights.ncols(),
+							id,
+							self.filter.clone(),
+						)
+					},
+				),
+			_ => {
+				bevy::log::error!("I think this should be unreachable, might want to handle this case explicitly if not");
+				GroundTriEdgeIter::none(self.filter.clone())
+			}
+		}
+	}
+}
+
+pub struct GroundTriEdgeIter<F> {
+	nrows: usize,
+	ncols: usize,
+	source: PlanetTri,
+	filter: F,
+	curr: TriNeighbor,
+}
+
+impl<F> GroundTriEdgeIter<F> {
+	fn new(nrows: usize, ncols: usize, source: PlanetTri, filter: F) -> Self {
+		Self {
+			nrows,
+			ncols,
+			source,
+			filter,
+			curr: TriNeighbor::A,
+		}
+	}
+	fn none(filter: F) -> Self {
+		Self {
+			nrows: 0,
+			ncols: 0,
+			source: default(),
+			filter,
+			curr: TriNeighbor::Done,
+		}
+	}
+
+	fn num_tris(&self) -> usize {
+		num_tris(self.nrows, self.ncols)
+	}
+
+	fn split_tri_id(&self) -> (usize, usize, bool) {
+		split_triangle_id(self.nrows, self.ncols, self.source.tri)
+	}
+
+	fn tri_id(&self, i: usize, j: usize, left: bool) -> u32 {
+		let tid = j * self.nrows + i;
+		if left {
+			tid as u32
+		} else {
+			(tid + self.num_tris() / 2) as u32
+		}
+	}
+}
+
+impl<F: NavEdgeFilter> Iterator for GroundTriEdgeIter<F> {
+	type Item = NavEdge;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		use TriNeighbor::*;
+		let source = self.source;
+		let chunk = source.chunk;
+		let (i, j, left) = self.split_tri_id();
+		loop {
+			match (self.curr, left) {
+				(A, left) => {
+					self.curr = B;
+
+					// Same square, other triangle
+					let a = NavEdge::GroundToGround {
+						source,
+						target: PlanetTri {
+							chunk,
+							tri: self.tri_id(i, j, !left),
+						},
+					};
+
+					if self.filter.test(a) {
+						return Some(a);
+					}
+				}
+				(B, true) => {
+					self.curr = C;
+
+					let up = if i > 0 {
+						NavEdge::GroundToGround {
+							source,
+							target: PlanetTri {
+								chunk,
+								tri: self.tri_id(i - 1, j, false),
+							},
+						}
+					} else {
+						NavEdge::GroundToGround {
+							source,
+							target: PlanetTri {
+								chunk: ChunkIndex {
+									x: chunk.x,
+									y: chunk.y - 1,
+								},
+								tri: self.tri_id(self.nrows - 1, j, false),
+							},
+						}
+					};
+
+					if self.filter.test(up) {
+						return Some(up);
+					}
+				}
+				(B, false) => {
+					self.curr = C;
+
+					let right = if j < self.ncols - 1 {
+						NavEdge::GroundToGround {
+							source,
+							target: PlanetTri {
+								chunk,
+								tri: self.tri_id(i, j + 1, true),
+							},
+						}
+					} else {
+						NavEdge::GroundToGround {
+							source,
+							target: PlanetTri {
+								chunk: ChunkIndex {
+									x: chunk.x + 1,
+									y: chunk.y,
+								},
+								tri: self.tri_id(i, 0, true),
+							},
+						}
+					};
+
+					if self.filter.test(right) {
+						return Some(right);
+					}
+				}
+				(C, true) => {
+					self.curr = Done;
+
+					let left = if j > 0 {
+						NavEdge::GroundToGround {
+							source,
+							target: PlanetTri {
+								chunk,
+								tri: self.tri_id(i, j - 1, false),
+							},
+						}
+					} else {
+						NavEdge::GroundToGround {
+							source,
+							target: PlanetTri {
+								chunk: ChunkIndex {
+									x: chunk.x - 1,
+									y: chunk.y,
+								},
+								tri: self.tri_id(i, self.ncols - 1, false),
+							},
+						}
+					};
+
+					if self.filter.test(left) {
+						return Some(left);
+					}
+				}
+				(C, false) => {
+					self.curr = Done;
+
+					let down = if i < self.nrows - 1 {
+						NavEdge::GroundToGround {
+							source,
+							target: PlanetTri {
+								chunk,
+								tri: self.tri_id(i + 1, j, true),
+							},
+						}
+					} else {
+						NavEdge::GroundToGround {
+							source,
+							target: PlanetTri {
+								chunk: ChunkIndex {
+									x: chunk.x + 1,
+									y: chunk.y,
+								},
+								tri: self.tri_id(i, 0, true),
+							},
+						}
+					};
+
+					if self.filter.test(down) {
+						return Some(down);
+					}
+				}
+				(Done, _) => return None,
+			}
+		}
+	}
+}
+
+pub struct AllGroundTris;
+
+impl NavEdgeFilter for AllGroundTris {
+	fn test(&mut self, edge: NavEdge) -> bool {
+		matches!(edge, NavEdge::GroundToGround { .. })
+	}
+}
+
+pub struct MaxClimb<'heights> {
+	pub chunks: &'heights HashMap<ChunkIndex, Weak<HeightField>>,
+	pub radians: f32,
+}
+
+impl NavEdgeFilter for MaxClimb<'_> {
+	fn test(&mut self, edge: NavEdge) -> bool {
+		let NavEdge::GroundToGround { source, target } = edge else {
+			return false;
+		};
+
+		let (si, sj, sl) = split_triangle_id(CHUNK_ROWS, CHUNK_COLS, source.tri);
+		let (ti, tj, _tl) = split_triangle_id(CHUNK_ROWS, CHUNK_COLS, target.tri);
+		let (si, sj, ti, tj) = (si as f32, sj as f32, ti as f32, tj as f32);
+		let dir = if si == ti && sj == tj {
+			// same cell, towards other triangle
+			if sl {
+				Vec3::new(SQRT_2, 0.0, SQRT_2)
+			} else {
+				Vec3::new(-SQRT_2, 0.0, -SQRT_2)
+			}
+		} else {
+			// towards closest triangle in adjacent cell
+			Vec3::new(tj - sj, 0.0, ti - si).normalize()
+		};
+		let Some(snorm) = self
+			.chunks
+			.get(&source.chunk)
+			.and_then(Weak::upgrade)
+			.and_then(|heights| heights.triangle_at_id(source.tri))
+			.and_then(|tri| tri.normal())
+			.as_deref()
+			.copied()
+		else {
+			return false;
+		};
+		if snorm.angle(&Vec3::Y.into()) > self.radians {
+			// Already on a steep slope
+			let dot = dir.dot(snorm.into());
+			if dot < 0.0 {
+				// Against normal -- Uphill
+				false
+			} else {
+				// With normal -- Downhill
+				true
+			}
+		} else {
+			// Not on steep slope, check slope of target
+			let Some(tnorm) = self
+				.chunks
+				.get(&target.chunk)
+				.and_then(Weak::upgrade)
+				.and_then(|heights| heights.triangle_at_id(source.tri))
+				.and_then(|tri| tri.normal())
+				.as_deref()
+				.copied()
+			else {
+				return false;
+			};
+			let dot = dir.dot(tnorm.into());
+			if dot < 0.0 {
+				// Against normal, so uphill
+				tnorm.angle(&Vec3::Y.into()) <= self.radians
+			} else {
+				// Normal is pointing away from us, so downhill
+				true
+			}
+		}
+	}
+}
+
+#[derive(Default, Copy, Clone, Debug)]
+enum TriNeighbor {
+	#[default]
+	A,
+	B,
+	C,
+	Done,
+}

--- a/rs/src/pickups.rs
+++ b/rs/src/pickups.rs
@@ -36,12 +36,7 @@ pub fn plugin(app: &mut App) -> &mut App {
 #[derive(Resource, Default, Debug, Clone, Deref, DerefMut)]
 pub struct PopSfx(pub Handle<AudioSource>);
 
-pub fn setup(
-	mut cmds: Commands,
-	mut meshes: ResMut<Assets<Mesh>>,
-	mut mats: ResMut<Assets<ExtendedMaterial<StandardMaterial, BubbleMaterial>>>,
-	asset_server: Res<AssetServer>,
-) {
+pub fn setup(mut cmds: Commands, mut meshes: ResMut<Assets<Mesh>>, asset_server: Res<AssetServer>) {
 	cmds.insert_resource(SpawnTimer(Timer::new(
 		Duration::from_secs(2),
 		TimerMode::Repeating,

--- a/rs/src/planet.rs
+++ b/rs/src/planet.rs
@@ -1,6 +1,6 @@
 use crate::{planet::day_night::DayNightCycle, util::IntoFnPlugin};
 use bevy::prelude::*;
-use bevy_rapier3d::{na::Vector2, parry::math::Vector};
+use bevy_rapier3d::na::{Vector2, Vector3};
 use serde::{Deserialize, Serialize};
 use std::ops::{Add, Sub};
 
@@ -15,14 +15,12 @@ pub fn plugin(app: &mut App) -> &mut App {
 		.register_type::<DayNightCycle>()
 }
 
-#[derive(
-	Component, Default, Debug, Copy, Clone, Deref, DerefMut, PartialEq, Serialize, Deserialize,
-)]
-pub struct PlanetVec3(pub Vector<f64>);
+#[derive(Default, Debug, Copy, Clone, Deref, DerefMut, PartialEq, Serialize, Deserialize)]
+pub struct PlanetVec3(pub Vector3<f64>);
 
 impl PlanetVec3 {
 	pub fn new(x: f64, y: f64, z: f64) -> Self {
-		Self(Vector::new(x, y, z))
+		Self(Vector3::new(x, y, z))
 	}
 
 	pub fn relative_to(self, other: Self) -> Vec3 {
@@ -33,7 +31,7 @@ impl PlanetVec3 {
 
 impl From<Vec3> for PlanetVec3 {
 	fn from(value: Vec3) -> Self {
-		Self(Vector::new(value.x as f64, value.y as f64, value.z as f64))
+		Self(Vector3::new(value.x as f64, value.y as f64, value.z as f64))
 	}
 }
 
@@ -59,7 +57,7 @@ impl Add<Vec3> for PlanetVec3 {
 	type Output = Self;
 
 	fn add(self, rhs: Vec3) -> Self::Output {
-		let rhs = Vector::new(rhs.x as f64, rhs.y as f64, rhs.z as f64);
+		let rhs = Vector3::new(rhs.x as f64, rhs.y as f64, rhs.z as f64);
 		Self(*self + rhs)
 	}
 }
@@ -76,7 +74,7 @@ impl Sub<Vec3> for PlanetVec3 {
 	type Output = Self;
 
 	fn sub(self, rhs: Vec3) -> Self::Output {
-		let rhs = Vector::new(rhs.x as f64, rhs.y as f64, rhs.z as f64);
+		let rhs = Vector3::new(rhs.x as f64, rhs.y as f64, rhs.z as f64);
 		Self(*self - rhs)
 	}
 }

--- a/rs/src/planet/chunks.rs
+++ b/rs/src/planet/chunks.rs
@@ -1,9 +1,50 @@
 use super::terrain::Ground;
-use crate::planet::PlanetVec3;
-use bevy::prelude::*;
+use crate::planet::PlanetVec2;
+use bevy::{prelude::*, utils::HashMap};
+
+pub const CHUNK_SIZE: f32 = 128.0;
+pub const CHUNK_ROWS: usize = CHUNK_SIZE as usize;
+pub const CHUNK_COLS: usize = CHUNK_SIZE as usize;
 
 #[derive(Bundle, Debug)]
 pub struct ChunkBundle {
-	pub center: PlanetVec3,
+	pub center: ChunkCenter,
+	pub index: ChunkIndex,
 	pub ground: Ground,
 }
+
+#[derive(Component, Debug, Default, Deref, DerefMut)]
+pub struct ChunkCenter(PlanetVec2);
+
+#[derive(Component, Copy, Clone, Default, Debug, Hash, PartialEq, Eq)]
+pub struct ChunkIndex {
+	pub x: i32,
+	pub y: i32,
+}
+
+impl ChunkIndex {
+	pub fn new(x: i32, y: i32) -> Self {
+		Self { x, y }
+	}
+}
+
+impl From<ChunkIndex> for ChunkCenter {
+	fn from(value: ChunkIndex) -> Self {
+		Self(PlanetVec2::new(
+			value.x as f64 * CHUNK_SIZE as f64,
+			value.y as f64 * CHUNK_SIZE as f64,
+		))
+	}
+}
+
+impl From<PlanetVec2> for ChunkIndex {
+	fn from(value: PlanetVec2) -> Self {
+		Self::new(
+			((value.x / CHUNK_SIZE as f64) + 0.5) as i32,
+			((value.y / CHUNK_SIZE as f64) + 0.5) as i32,
+		)
+	}
+}
+
+#[derive(Resource, Default, Debug, Deref, DerefMut)]
+pub struct LoadedChunks(HashMap<ChunkIndex, Entity>);

--- a/rs/src/player/camera.rs
+++ b/rs/src/player/camera.rs
@@ -2,7 +2,7 @@ use super::{
 	player_entity::{Cam, CamPivot},
 	BelongsToPlayer, G1,
 };
-use crate::{planet::sky::SkyShader, player::PlayerId, settings::Settings};
+use crate::{NeverDespawn, planet::sky::SkyShader, player::PlayerId, settings::Settings};
 
 use bevy::{
 	core_pipeline::{
@@ -113,6 +113,7 @@ pub fn spawn_camera<'w, 's, 'a>(
 		Collider::ball(2.0),
 		CollisionGroups::new(Group::empty(), Group::empty()),
 		CamTarget::default(),
+		NeverDespawn,
 	));
 	cmds.set_enum(Cam).with_children(|builder| {
 		let manual_tv_handle = ManualTextureViewHandle(player_id.get() as u32 - 1);
@@ -154,6 +155,7 @@ pub fn spawn_camera<'w, 's, 'a>(
 				enabled: settings.fxaa,
 				..default()
 			},
+			NeverDespawn,
 		));
 	});
 	cmds

--- a/rs/src/player/camera.rs
+++ b/rs/src/player/camera.rs
@@ -5,7 +5,10 @@ use super::{
 use crate::{planet::sky::SkyShader, player::PlayerId, settings::Settings};
 
 use bevy::{
-	core_pipeline::{bloom::BloomSettings, clear_color::ClearColorConfig, fxaa::Fxaa, Skybox},
+	core_pipeline::{
+		bloom::BloomSettings, clear_color::ClearColorConfig, fxaa::Fxaa, tonemapping::Tonemapping,
+		Skybox,
+	},
 	ecs::system::{EntityCommands, Res},
 	prelude::*,
 	render::{
@@ -26,7 +29,6 @@ use bevy_rapier3d::{
 };
 use enum_components::{ERef, EntityEnumCommands};
 use std::f32::consts::FRAC_PI_2;
-use bevy::core_pipeline::tonemapping::Tonemapping;
 
 pub const CAM_ACCEL: f32 = 12.0;
 const MAX_CAM_DIST: f32 = 24.0;
@@ -166,7 +168,7 @@ pub fn spawn_pivot<'w, 's, 'a>(
 			owner,
 			CameraVertSlider(0.4),
 			TransformBundle::from_transform(Transform {
-				translation: Vect::new(0.0, 6.4, 0.0),
+				translation: Vect::new(0.0, 0.0, 6.4),
 				..default()
 			}),
 		))

--- a/rs/src/player/input.rs
+++ b/rs/src/player/input.rs
@@ -29,6 +29,7 @@ use std::{
 	f32::consts::{FRAC_PI_3, PI, TAU},
 	time::Duration,
 };
+use std::f32::consts::FRAC_PI_2;
 
 pub fn plugin(app: &mut App) -> &mut App {
 	app.add_plugins((
@@ -320,7 +321,7 @@ pub fn look_input(
 			slider.0 = (slider.0 + mouse.y * 0.1).clamp(0.0, 1.0);
 		}
 
-		let angle = (-PI).lerp(-PI * 0.1, slider.0);
+		let angle = (-FRAC_PI_2).lerp(FRAC_PI_2 * 0.9, slider.0);
 		xform.rotation = xform.rotation.slerp(Quat::from_rotation_x(angle), delta);
 	}
 }

--- a/rs/src/player/input.rs
+++ b/rs/src/player/input.rs
@@ -26,10 +26,9 @@ use leafwing_input_manager::prelude::*;
 use particles::Spewer;
 use serde::{Deserialize, Serialize};
 use std::{
-	f32::consts::{FRAC_PI_3, PI, TAU},
+	f32::consts::{FRAC_PI_2, FRAC_PI_3, PI, TAU},
 	time::Duration,
 };
-use std::f32::consts::FRAC_PI_2;
 
 pub fn plugin(app: &mut App) -> &mut App {
 	app.add_plugins((
@@ -386,7 +385,9 @@ pub fn grab_mouse(
 	key: Res<Input<KeyCode>>,
 	ui_hovered: Res<UiHovered>,
 ) {
-	let mut window = windows.single_mut();
+	let Ok(mut window) = windows.get_single_mut() else { // probably exiting if window is missing
+		return;
+	};
 
 	if mouse.just_pressed(MouseButton::Left) && !**ui_hovered {
 		window.cursor.visible = false;

--- a/rs/src/util.rs
+++ b/rs/src/util.rs
@@ -314,8 +314,7 @@ where
 {
 }
 
-
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialOrd, PartialEq, Ord, Eq, Hash)]
 pub enum Todo {}
 
 pub struct RonReflectAssetLoader<T> {

--- a/rs/src/util.rs
+++ b/rs/src/util.rs
@@ -85,19 +85,21 @@ pub fn consume_spawn_events<T: Spawnable>(
 	}
 }
 
-pub trait Lerp<R, T>
+pub trait Lerp<Rhs, T>
 where
 	Self: Clone,
-	R: Sub<Self>,
-	<R as Sub<Self>>::Output: Mul<T>,
-	<<R as Sub<Self>>::Output as Mul<T>>::Output: Add<Self>,
+	Rhs: Sub<Self>,
+	<Rhs as Sub<Self>>::Output: Mul<T>,
+	<<Rhs as Sub<Self>>::Output as Mul<T>>::Output: Add<Self>,
 {
+	type Output;
+
 	#[inline(always)]
 	fn lerp(
 		self,
-		rhs: R,
+		rhs: Rhs,
 		t: T,
-	) -> <<<R as Sub<Self>>::Output as Mul<T>>::Output as Add<Self>>::Output {
+	) -> <<<Rhs as Sub<Self>>::Output as Mul<T>>::Output as Add<Self>>::Output {
 		((rhs - self.clone()) * t) + self
 	}
 }
@@ -109,6 +111,7 @@ where
 	<R as Sub<This>>::Output: Mul<T>,
 	<<R as Sub<This>>::Output as Mul<T>>::Output: Add<This>,
 {
+	type Output = <<<R as Sub<This>>::Output as Mul<T>>::Output as Add<This>>::Output;
 }
 
 #[derive(Resource, Component)]


### PR DESCRIPTION
Moves shape casting code from Rapier into this repo with some modifications.

Unfortunately, low framerates still have tunnelling issues, and this can even happen with a good computer if the OS happens to freeze for a split second at the wrong time. I'm not sure why penetrations are happening so often even with the buffer value subtracted from the TOI, and sadly the normals returned by `contact_manifolds` are highly variable. Sometimes this results in normals that push the player up slopes they should not be able to climb, but trying to prevent that makes it even easier for the player to fall through the world.

The issues are primarily with heightmaps, which are queried as a bunch of individual triangles. I might have to fork Rapier/Parry and add the ability to specify that normals should always be on the upper side of the triangles for heightmaps, rather than whichever side the collider is already mostly on. 

There could also be some bug with my fixed timestep implementation when the rendering framerate is lower than the physics tick rate, and `move_player` has to step multiple times with shorter casts, but I have not been able to find it. Between that issue and the unexpected penetrations (which were happening with the built-in controller as well), I feel like it might be more of a limitation of shape casting rather than my usage of it.