### PR TITLE
Movement abilities

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "sond-bevy-particles"]
 	path = sond-bevy-particles
 	url = git@github.com:Waridley/bevy-particles.git
-[submodule "leafwing_abilities"]
-	path = leafwing_abilities
-	url = git@github.com:k-specht/leafwing_abilities.git

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -1413,9 +1413,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+checksum = "ed2490600f404f2b94c167e31d3ed1d5f3c225a0f3b80230053b3e0b7b962bd9"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -1589,12 +1589,6 @@ checksum = "edd23e864550e6dafc1e41ac78ce4f1ccddc8672b40c403524a04ff3f0518420"
 dependencies = [
  "const_soft_float",
 ]
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "convert_case"
@@ -1784,10 +1778,8 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
- "convert_case 0.4.0",
  "proc-macro2",
  "quote",
- "rustc_version",
  "syn 1.0.109",
 ]
 
@@ -2721,28 +2713,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leafwing_abilities"
-version = "0.5.0"
-dependencies = [
- "bevy",
- "derive_more",
- "leafwing-input-manager",
- "leafwing_abilities_macros",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "leafwing_abilities_macros"
-version = "0.3.0"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "leafwing_input_manager_macros"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3210,6 +3180,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3365,7 +3346,7 @@ dependencies = [
  "jni 0.20.0",
  "ndk",
  "ndk-context",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "oboe-sys",
 ]
@@ -3464,9 +3445,9 @@ dependencies = [
 
 [[package]]
 name = "parry3d"
-version = "0.13.5"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55dc0e6db79bddbc5fd583569f7356cdcc63e1e9b2b93a9ab70dd8e717160e0"
+checksum = "13d0bdaf533851feec5cba9af11cefcc753ecefba05f758cf6abe886086bc3f5"
 dependencies = [
  "approx",
  "arrayvec",
@@ -3474,7 +3455,7 @@ dependencies = [
  "downcast-rs",
  "either",
  "nalgebra",
- "num-derive",
+ "num-derive 0.4.1",
  "num-traits",
  "rustc-hash",
  "serde",
@@ -3732,7 +3713,7 @@ dependencies = [
  "downcast-rs",
  "instant",
  "nalgebra",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "parry3d",
  "rustc-hash",
@@ -3804,7 +3785,7 @@ checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.4",
+ "regex-automata 0.4.5",
  "regex-syntax 0.8.2",
 ]
 
@@ -3819,9 +3800,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7fa1134405e2ec9353fd416b17f8dacd46c473d7d3fd1cf202706a14eb792a"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3924,15 +3905,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "0.38.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3987,12 +3959,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "semver"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
-
-[[package]]
 name = "send_wrapper"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4000,18 +3966,18 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4020,9 +3986,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.111"
+version = "1.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+checksum = "4d1bd37ce2324cf3bf85e5a25f96eb4baf0d5aa6eba43e7ae8958870c4ec48ed"
 dependencies = [
  "itoa",
  "ryu",
@@ -4120,7 +4086,7 @@ dependencies = [
 name = "sond-bevy-enum-components-macros"
 version = "0.1.0"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case",
  "proc-macro-crate 2.0.1",
  "proc-macro2",
  "quote",
@@ -4152,7 +4118,6 @@ dependencies = [
  "fixedbitset",
  "futures-lite 2.2.0",
  "leafwing-input-manager",
- "leafwing_abilities",
  "nanorand",
  "noise",
  "num-traits",
@@ -5256,9 +5221,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.5.34"
+version = "0.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
+checksum = "1931d78a9c73861da0134f453bb1f790ce49b2e30eba8410b4b79bac72b46a2d"
 dependencies = [
  "memchr",
 ]

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -20,9 +20,6 @@ default = [
 
 
 [patch.crates-io]
-#rapier3d = { version = "0.16", path = "../rapier/crates/rapier3d" }
-#bevy_rapier3d = { version = "0.23.0", path = "../bevy_rapier/bevy_rapier3d" }
-leafwing_abilities = { version = "0.5.0", path = "../leafwing_abilities" }
 proc-macro-crate = { version = "2", git = "https://github.com/Waridley/proc-macro-crate.git", branch = "root_workspace_deps" }
 
 [workspace.dependencies.bevy]
@@ -70,7 +67,6 @@ bevy_rapier3d = { version = "0.23.0", default-features = false, features = ["dim
 rapier3d = { version = "0.17.2", features = ["wasm-bindgen", "serde-serialize"] }
 bevy_kira_audio = "0.18.0"
 leafwing-input-manager = "0.11.1"
-leafwing_abilities = "0.5.0"
 bevy_quickmenu = "0.2.0"
 bevy_common_assets = { version = "0.8.0", features = ["ron"] }
 
@@ -105,8 +101,6 @@ bevy_rapier3d = { workspace = true }
 rapier3d = { workspace = true }
 bevy_kira_audio = { workspace = true }
 leafwing-input-manager = { workspace = true }
-leafwing_abilities = { workspace = true }
-#bevy_quickmenu = { workspace = true }
 bevy_common_assets = { workspace = true }
 
 # Util

--- a/rs/assets/tune/player_params.ron
+++ b/rs/assets/tune/player_params.ron
@@ -1,0 +1,24 @@
+#![enable(unwrap_newtypes)]
+(
+	abil: (
+		grounded_booster_charge: 100.0,
+		weapon_capacity: 100.0,
+		weapon_fill_per_second: 25.0,
+		jump_cost: 50.0,
+		jump_vel: 64.0,
+		dash_cost: 50.0,
+		dash_vel: 256.0,
+		aoe_cost: 50.0,
+	),
+	phys: (
+		max_speed: 64.0,
+		accel: 3.0,
+		gravity: 64.0,
+		climb_angle: Deg(59.0),
+		slide_angle: Deg(59.0),
+		hover_height: 2.0,
+		collider: (
+			radius: 1.2,
+		),
+	),
+)

--- a/rs/assets/tune/player_params.ron.meta
+++ b/rs/assets/tune/player_params.ron.meta
@@ -1,0 +1,7 @@
+(
+    meta_format_version: "1.0",
+    asset: Load(
+        loader: "bevy_common_assets::ron::RonAssetLoader<sond_has::player::tune::PlayerParams>",
+        settings: (),
+    ),
+)

--- a/rs/src/abilities.rs
+++ b/rs/src/abilities.rs
@@ -1,1 +1,58 @@
+use crate::{
+	anim::*,
+	player::{input::PlayerAction, BelongsToPlayer},
+};
+use bevy::prelude::*;
+use leafwing_input_manager::action_state::ActionState;
+use leafwing_input_manager::axislike::DualAxisData;
+use leafwing_input_manager::systems::update_action_state;
+use crate::player::{DASH_COST, DASH_VEL, JUMP_COST, JUMP_VEL};
+use crate::player::ctrl::CtrlVel;
 
+pub struct AbilitiesPlugin;
+
+impl Plugin for AbilitiesPlugin {
+	fn build(&self, app: &mut App) {
+		app.add_systems(Update, trigger_player_abilities.after(update_action_state::<PlayerAction>));
+	}
+}
+
+pub fn trigger_player_abilities(
+	mut cmds: Commands,
+	mut q: Query<(
+		&ActionState<PlayerAction>,
+		&mut BoosterCharge,
+		&mut CtrlVel,
+		&BelongsToPlayer,
+	)>,
+) {
+	use PlayerAction::*;
+	for (state, mut charge, mut vel, owner) in &mut q {
+		if state.just_pressed(Jump) && **charge >= JUMP_COST {
+			**charge = f32::max(0.0, **charge - JUMP_COST);
+			vel.linvel.z = JUMP_VEL
+		}
+		
+		if state.just_pressed(Dash) && **charge >= DASH_COST {
+			**charge = f32::max(0.0, **charge - DASH_COST);
+			// Use the just-input direction, not current velocity, to dash in the direction the player expects
+			let dir = if let Some(dir) = state.clamped_axis_pair(Move).as_ref().and_then(DualAxisData::direction) {
+				dir.unit_vector()
+			} else {
+				// Forward
+				Vec2::new(0.0, 1.0)
+			} * DASH_VEL;
+			vel.linvel.x = dir.x;
+			vel.linvel.y = dir.y;
+		}
+	}
+}
+
+#[derive(Component, Deref, DerefMut, Debug, PartialEq, PartialOrd)]
+pub struct BoosterCharge(pub f32);
+
+impl Default for BoosterCharge {
+	fn default() -> Self {
+		Self(JUMP_VEL * 2.0)
+	}
+}

--- a/rs/src/abilities.rs
+++ b/rs/src/abilities.rs
@@ -1,19 +1,33 @@
 use crate::{
-	anim::*,
-	player::{input::PlayerAction, BelongsToPlayer},
+	player::{
+		ctrl::CtrlVel,
+		input::PlayerAction,
+		player_entity::{Arm, Arms},
+		tune::{AbilityParams, PlayerParams},
+		BelongsToPlayer, RotVel,
+	},
+	util::Lerp,
 };
 use bevy::prelude::*;
-use leafwing_input_manager::action_state::ActionState;
-use leafwing_input_manager::axislike::DualAxisData;
-use leafwing_input_manager::systems::update_action_state;
-use crate::player::{DASH_COST, DASH_VEL, JUMP_COST, JUMP_VEL};
-use crate::player::ctrl::CtrlVel;
+use bevy_kira_audio::{Audio, AudioControl};
+use enum_components::ERef;
+use leafwing_input_manager::{
+	action_state::ActionState, axislike::DualAxisData, systems::update_action_state,
+};
+use particles::Spewer;
+use serde::{Deserialize, Serialize};
+use std::{f32::consts::FRAC_PI_3, time::Duration};
 
 pub struct AbilitiesPlugin;
 
 impl Plugin for AbilitiesPlugin {
 	fn build(&self, app: &mut App) {
-		app.add_systems(Update, trigger_player_abilities.after(update_action_state::<PlayerAction>));
+		app.add_systems(
+			Update,
+			(trigger_player_abilities, fill_weapons)
+				.after(update_action_state::<PlayerAction>)
+				.run_if(resource_exists::<PlayerParams>()),
+		);
 	}
 }
 
@@ -22,37 +36,121 @@ pub fn trigger_player_abilities(
 	mut q: Query<(
 		&ActionState<PlayerAction>,
 		&mut BoosterCharge,
+		&mut WeaponCharge,
 		&mut CtrlVel,
 		&BelongsToPlayer,
 	)>,
+	mut arms_q: Query<&mut RotVel, ERef<Arms>>,
+	mut arm_q: Query<(&mut Transform, &mut Spewer), ERef<Arm>>,
+	sfx: Res<AoESound>,
+	audio: Res<Audio>,
+	params: Res<PlayerParams>,
+	t: Res<Time>,
 ) {
+	// TODO: Cooldowns
 	use PlayerAction::*;
-	for (state, mut charge, mut vel, owner) in &mut q {
-		if state.just_pressed(Jump) && **charge >= JUMP_COST {
-			**charge = f32::max(0.0, **charge - JUMP_COST);
-			vel.linvel.z = JUMP_VEL
+	for (state, mut boost_charge, mut weap_charge, mut vel, owner) in &mut q {
+		let AbilityParams {
+			jump_cost,
+			jump_vel,
+			dash_cost,
+			dash_vel,
+			aoe_cost,
+			..
+		} = params.abil;
+		if state.just_pressed(Jump) && *boost_charge >= jump_cost {
+			**boost_charge -= *jump_cost;
+			vel.linvel.z = jump_vel
 		}
-		
-		if state.just_pressed(Dash) && **charge >= DASH_COST {
-			**charge = f32::max(0.0, **charge - DASH_COST);
-			// Use the just-input direction, not current velocity, to dash in the direction the player expects
-			let dir = if let Some(dir) = state.clamped_axis_pair(Move).as_ref().and_then(DualAxisData::direction) {
+
+		if state.just_pressed(Dash) && *boost_charge >= dash_cost {
+			**boost_charge -= *dash_cost;
+			// Use the most-recently-input direction, not current velocity, to dash in the direction the player expects.
+			let dir = if let Some(dir) = state
+				.clamped_axis_pair(Move)
+				.as_ref()
+				.and_then(DualAxisData::direction)
+			{
 				dir.unit_vector()
 			} else {
-				// Forward
+				// Default to forward if no input.
+				// Even if already moving in some direction, a lack of movement input indicates
+				// the player is expecting the dash button to do the default thing.
 				Vec2::new(0.0, 1.0)
-			} * DASH_VEL;
+			} * dash_vel;
 			vel.linvel.x = dir.x;
 			vel.linvel.y = dir.y;
 		}
+
+		if state.just_pressed(AoE) && *weap_charge >= aoe_cost {
+			**weap_charge -= *aoe_cost;
+			audio.play(sfx.0.clone()).with_volume(0.5);
+			for mut rvel in &mut arms_q {
+				**rvel = 36.0;
+			}
+			for (mut arm, mut spewer) in &mut arm_q {
+				// TODO: Filter by player
+				arm.translation *= 6.0;
+				arm.scale *= 6.0;
+				spewer.interval = Duration::from_micros(200);
+			}
+		}
+
+		// TODO: Use animation instead of limit lerp
+		for mut rvel in &mut arms_q {
+			**rvel = **rvel + (rvel.quiescent - **rvel) * t.delta_seconds();
+		}
+		for (i, (mut arm, mut spewer)) in arm_q.iter_mut().enumerate() {
+			let resting = Quat::from_rotation_z(i as f32 * FRAC_PI_3 * 2.0) * Vec3::X * 2.0;
+			arm.translation = arm.translation.lerp(resting, t.delta_seconds() * 2.0);
+			arm.scale = arm.scale.lerp(Vec3::ONE, t.delta_seconds() * 2.0);
+			spewer.interval = Duration::from_secs_f32(
+				spewer.interval.as_secs_f32().lerp(0.001, t.delta_seconds()),
+			);
+		}
 	}
 }
 
-#[derive(Component, Deref, DerefMut, Debug, PartialEq, PartialOrd)]
+#[derive(
+	Component,
+	Deref,
+	DerefMut,
+	Serialize,
+	Deserialize,
+	Copy,
+	Clone,
+	Default,
+	Debug,
+	PartialEq,
+	PartialOrd,
+)]
 pub struct BoosterCharge(pub f32);
 
-impl Default for BoosterCharge {
-	fn default() -> Self {
-		Self(JUMP_VEL * 2.0)
+#[derive(
+	Component,
+	Deref,
+	DerefMut,
+	Serialize,
+	Deserialize,
+	Copy,
+	Clone,
+	Default,
+	Debug,
+	PartialEq,
+	PartialOrd,
+)]
+pub struct WeaponCharge(pub f32);
+
+pub fn fill_weapons(mut q: Query<&mut WeaponCharge>, params: Res<PlayerParams>, t: Res<Time>) {
+	for mut charge in &mut q {
+		if *charge <= params.abil.weapon_capacity {
+			**charge = f32::min(
+				*params.abil.weapon_capacity,
+				**charge + *params.abil.weapon_fill_per_second * t.delta_seconds(),
+			);
+		}
 	}
 }
+
+#[derive(Debug, Resource, Deref, DerefMut)]
+pub struct AoESound(pub Handle<bevy_kira_audio::AudioSource>);

--- a/rs/src/anim.rs
+++ b/rs/src/anim.rs
@@ -564,10 +564,7 @@ where
 }
 
 pub trait StartAnimation<'w, 's, 'a> {
-	fn start_mut_animation<T: Component>(
-		&'a mut self,
-		tick: impl CurveMut<T>,
-	) -> Entity;
+	fn start_mut_animation<T: Component>(&'a mut self, tick: impl CurveMut<T>) -> Entity;
 	fn start_blendable_animation<
 		T: Component + Add<D, Output = T> + PartialEq + Clone,
 		D: Add<Output = D> + Mul<f32, Output = D> + 'static,
@@ -578,10 +575,7 @@ pub trait StartAnimation<'w, 's, 'a> {
 }
 
 impl<'w, 's, 'a> StartAnimation<'w, 's, 'a> for EntityCommands<'w, 's, 'a> {
-	fn start_mut_animation<T: Component>(
-		&'a mut self,
-		tick: impl CurveMut<T>,
-	) -> Entity {
+	fn start_mut_animation<T: Component>(&'a mut self, tick: impl CurveMut<T>) -> Entity {
 		let id = self.id();
 		self.commands().spawn(MutAnimation::new(id, tick)).id()
 	}
@@ -594,7 +588,9 @@ impl<'w, 's, 'a> StartAnimation<'w, 's, 'a> for EntityCommands<'w, 's, 'a> {
 		tick: impl BlendableCurve<T, D>,
 	) -> Entity {
 		let id = self.id();
-		self.commands().spawn(BlendableAnimation::new(id, tick)).id()
+		self.commands()
+			.spawn(BlendableAnimation::new(id, tick))
+			.id()
 	}
 }
 

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -16,13 +16,13 @@ use player::ctrl::CtrlVel;
 use std::{f32::consts::*, fmt::Debug, time::Duration};
 use util::{IntoFnPlugin, RonReflectAssetLoader};
 
+use crate::abilities::AbilitiesPlugin;
 #[allow(unused_imports, clippy::single_component_path_imports)]
 #[cfg(all(debug_assertions, not(target_arch = "wasm32")))]
 use bevy_dylib;
 use bevy_rapier3d::plugin::PhysicsSet::StepSimulation;
 use offloading::OffloadingPlugin;
 use planet::sky::SkyPlugin;
-use crate::abilities::AbilitiesPlugin;
 
 pub mod abilities;
 pub mod anim;

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -20,6 +20,9 @@ use util::{IntoFnPlugin, RonReflectAssetLoader};
 #[cfg(all(debug_assertions, not(target_arch = "wasm32")))]
 use bevy_dylib;
 use bevy_rapier3d::plugin::PhysicsSet::StepSimulation;
+use offloading::OffloadingPlugin;
+use planet::sky::SkyPlugin;
+use crate::abilities::AbilitiesPlugin;
 
 pub mod abilities;
 pub mod anim;
@@ -102,8 +105,9 @@ pub fn game_plugin(app: &mut App) -> &mut App {
 		FrameTimeDiagnosticsPlugin,
 		AudioPlugin,
 		ParticlesPlugin,
-		offloading::OffloadingPlugin,
-		planet::sky::SkyPlugin,
+		AbilitiesPlugin,
+		OffloadingPlugin,
+		SkyPlugin,
 		enemies::plugin.plugfn(),
 		player::plugin.plugfn(),
 		pickups::plugin.plugfn(),
@@ -243,28 +247,29 @@ fn startup(
 	});
 }
 
-fn terminal_velocity(mut q: Query<(&mut CtrlVel, &TerminalVelocity)>) {
+fn terminal_velocity(mut q: Query<(&mut CtrlVel, &TerminalVelocity)>, t: Res<Time>) {
+	let dt = t.delta_seconds();
 	for (mut vel, term_vel) in q.iter_mut() {
 		// Don't trigger vel.deref_mut if not necessary
 		let term = term_vel.linvel;
 		if vel.linvel.x.abs() > term.x {
-			vel.linvel.x = term.x * vel.linvel.x.signum()
+			vel.linvel.x -= dt * vel.linvel.x.signum()
 		}
 		if vel.linvel.y.abs() > term.y {
-			vel.linvel.y = term.y * vel.linvel.y.signum()
+			vel.linvel.y -= dt * vel.linvel.y.signum()
 		}
 		if vel.linvel.z.abs() > term.z {
-			vel.linvel.z = term.z * vel.linvel.z.signum()
+			vel.linvel.z -= dt * vel.linvel.z.signum()
 		}
 		let term = term_vel.angvel;
 		if vel.angvel.x.abs() > term.x {
-			vel.angvel.x = term.x * vel.angvel.x.signum()
+			vel.angvel.x -= dt * vel.angvel.x.signum()
 		}
 		if vel.angvel.y.abs() > term.y {
-			vel.angvel.y = term.y * vel.angvel.y.signum()
+			vel.angvel.y -= dt * vel.angvel.y.signum()
 		}
 		if vel.angvel.z.abs() > term.z {
-			vel.angvel.z = term.z * vel.angvel.z.signum()
+			vel.angvel.z -= dt * vel.angvel.z.signum()
 		}
 	}
 }

--- a/rs/src/player.rs
+++ b/rs/src/player.rs
@@ -48,11 +48,15 @@ pub mod ctrl;
 pub mod input;
 pub mod prefs;
 
+// TODO: These should be in a text resource. Maybe const in release builds.
 pub const MAX_SPEED: f32 = 64.0;
 pub const ACCEL: f32 = 3.0;
 pub const PLAYER_GRAVITY: f32 = 64.0;
 pub const MAX_JUMPS: f32 = 2.0;
 pub const JUMP_VEL: f32 = 64.0;
+pub const JUMP_COST: f32 = 64.0;
+pub const DASH_VEL: f32 = 196.0;
+pub const DASH_COST: f32 = 64.0;
 pub const CLIMB_ANGLE: f32 = FRAC_PI_3 - R_EPS;
 pub const SLIDE_ANGLE: f32 = FRAC_PI_3 - R_EPS;
 pub const HOVER_HEIGHT: f32 = 2.0;
@@ -69,6 +73,7 @@ pub enum InterpolatedXforms {
 pub fn plugin(app: &mut App) -> &mut App {
 	app.add_plugins(input::plugin.plugfn())
 		.add_systems(Startup, setup)
+		.add_systems(First, Prev::<CtrlState>::update_component)
 		.add_systems(
 			Update,
 			(
@@ -212,6 +217,8 @@ pub enum PlayerEntity {
 	Arm(PlayerArm),
 }
 use player_entity::*;
+use crate::abilities::BoosterCharge;
+use crate::util::Prev;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum PlayerArm {
@@ -380,6 +387,7 @@ fn player_controller(root: &mut EntityCommands, owner: BelongsToPlayer, char_col
 				},
 				PlayerAction::abilities_bundle(),
 				CtrlState::default(),
+				BoosterCharge::default(),
 				(invert_camera, fov, sens),
 			))
 			.with_enum(Controller);

--- a/rs/src/player/ctrl.rs
+++ b/rs/src/player/ctrl.rs
@@ -1,7 +1,6 @@
 use crate::{
 	abilities::BoosterCharge,
 	player::{
-		input::PlayerAction,
 		player_entity::{Controller, Root, ShipCenter},
 		tune::PlayerParams,
 		BelongsToPlayer, G1,
@@ -21,7 +20,6 @@ use bevy_rapier3d::{
 	prelude::*,
 };
 use enum_components::ERef;
-use leafwing_abilities::prelude::*;
 use rapier3d::{
 	math::Isometry,
 	parry::query::ContactManifold,

--- a/rs/src/player/ctrl.rs
+++ b/rs/src/player/ctrl.rs
@@ -25,8 +25,9 @@ use rapier3d::{
 	parry::query::ContactManifold,
 	prelude::{ContactData, ContactManifoldData},
 };
+use crate::abilities::BoosterCharge;
 
-#[derive(Component, Default)]
+#[derive(Component, Default, Clone, Debug)]
 pub struct CtrlState {
 	pub touching_ground: bool,
 	pub bottomed_out: bool,
@@ -154,8 +155,8 @@ pub fn player_repel_ground(
 	}
 }
 
-pub fn reset_jump_on_ground(mut q: Query<(AbilityState<PlayerAction>, &CtrlState)>) {
-	for (mut state, ctrl_state) in &mut q {
+pub fn reset_jump_on_ground(mut q: Query<(AbilityState<PlayerAction>, &CtrlState, &mut BoosterCharge), Changed<CtrlState>>) {
+	for (mut state, ctrl_state, mut charge) in &mut q {
 		if ctrl_state.touching_ground
 			&& state
 				.cooldowns
@@ -167,6 +168,10 @@ pub fn reset_jump_on_ground(mut q: Query<(AbilityState<PlayerAction>, &CtrlState
 		{
 			let charges = state.charges.get_mut(PlayerAction::Jump).as_mut().unwrap();
 			charges.set_charges(charges.max_charges());
+		}
+		
+		if ctrl_state.touching_ground && *charge < BoosterCharge::default() {
+			*charge = BoosterCharge::default()
 		}
 	}
 }

--- a/rs/src/player/input.rs
+++ b/rs/src/player/input.rs
@@ -29,6 +29,7 @@ use std::{
 	f32::consts::{FRAC_PI_2, FRAC_PI_3, TAU},
 	time::Duration,
 };
+use crate::player::input::PlayerAction::Move;
 
 pub fn plugin(app: &mut App) -> &mut App {
 	app.add_plugins((
@@ -44,7 +45,7 @@ pub fn plugin(app: &mut App) -> &mut App {
 			look_input
 				.before(terminal_velocity)
 				.before(super::ctrl::move_player),
-			jump.before(terminal_velocity),
+			// jump.before(terminal_velocity),
 		),
 	)
 }
@@ -77,8 +78,11 @@ fn setup(
 	Deserialize,
 )]
 pub enum PlayerAction {
+	Move,
+	Look,
 	Jump,
 	AoE,
+	Dash,
 	Pause,
 }
 
@@ -87,9 +91,10 @@ impl PlayerAction {
 		use PlayerAction::*;
 
 		let secs = match *self {
-			Jump => 0.128, // debouncing
+			Move | Look | Pause => return None,
+			Jump => 0.128,
 			AoE => 2.5,
-			Pause => return None,
+			Dash => 0.128,
 		};
 
 		Some(Cooldown::from_secs(secs))

--- a/rs/src/player/prefs.rs
+++ b/rs/src/player/prefs.rs
@@ -41,6 +41,7 @@ impl Default for PlayerPrefs {
 			(KeyCode::Space, Jump),
 			(KeyCode::ShiftLeft, Dash),
 			(KeyCode::E, AoE),
+			(KeyCode::PageUp, AoE),
 			(KeyCode::Escape, Pause),
 		]);
 		input_map.insert_multiple([
@@ -57,9 +58,7 @@ impl Default for PlayerPrefs {
 			(GamepadButtonType::RightTrigger, AoE),
 			(GamepadButtonType::Start, Pause),
 		]);
-		input_map.insert_multiple([
-			(MouseButton::Other(5), Dash) // Browser forward
-		]);
+		input_map.insert_multiple([(MouseButton::Other(9), Dash)]);
 		Self {
 			invert_camera: default(),
 			fov: default(),

--- a/rs/src/player/prefs.rs
+++ b/rs/src/player/prefs.rs
@@ -39,13 +39,26 @@ impl Default for PlayerPrefs {
 		let mut input_map = InputMap::new([
 			(KeyCode::Back, Jump),
 			(KeyCode::Space, Jump),
+			(KeyCode::ShiftLeft, Dash),
 			(KeyCode::E, AoE),
 			(KeyCode::Escape, Pause),
 		]);
 		input_map.insert_multiple([
+			(DualAxis::left_stick(), Move),
+			(DualAxis::right_stick(), Look),
+		]);
+		input_map.insert_multiple([
+			(VirtualDPad::wasd(), Move),
+			(VirtualDPad::arrow_keys(), Look),
+		]);
+		input_map.insert_multiple([
 			(GamepadButtonType::South, Jump),
+			(GamepadButtonType::West, Dash),
 			(GamepadButtonType::RightTrigger, AoE),
 			(GamepadButtonType::Start, Pause),
+		]);
+		input_map.insert_multiple([
+			(MouseButton::Other(5), Dash) // Browser forward
 		]);
 		Self {
 			invert_camera: default(),

--- a/rs/src/player/tune.rs
+++ b/rs/src/player/tune.rs
@@ -1,0 +1,52 @@
+use crate::{
+	abilities::{BoosterCharge, WeaponCharge},
+	util::Angle,
+};
+use bevy::prelude::*;
+use rapier3d::geometry::Ball;
+use serde::{Deserialize, Serialize};
+
+pub const MAX_JUMPS: f32 = 2.0;
+
+pub fn extract_loaded_params(
+	mut cmds: Commands,
+	params_assets: Res<Assets<PlayerParams>>,
+	mut events: EventReader<AssetEvent<PlayerParams>>,
+) {
+	for event in events.read() {
+		match event {
+			AssetEvent::Added { id } | AssetEvent::Modified { id } => {
+				cmds.insert_resource(dbg!(params_assets.get(*id).unwrap().clone()));
+			}
+			_ => {}
+		}
+	}
+}
+
+#[derive(Asset, TypePath, Resource, Serialize, Deserialize, Clone, Debug)]
+pub struct PlayerParams {
+	pub abil: AbilityParams,
+	pub phys: PlayerPhysicsParams,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
+pub struct AbilityParams {
+	pub grounded_booster_charge: BoosterCharge,
+	pub weapon_capacity: WeaponCharge,
+	pub weapon_fill_per_second: WeaponCharge,
+	pub jump_cost: BoosterCharge,
+	pub jump_vel: f32,
+	pub dash_cost: BoosterCharge,
+	pub dash_vel: f32,
+	pub aoe_cost: WeaponCharge,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
+pub struct PlayerPhysicsParams {
+	pub max_speed: f32,
+	pub accel: f32,
+	pub gravity: f32,
+	pub slide_angle: Angle,
+	pub hover_height: f32,
+	pub collider: Ball,
+}

--- a/rs/src/player/tune.rs
+++ b/rs/src/player/tune.rs
@@ -6,8 +6,6 @@ use bevy::prelude::*;
 use rapier3d::geometry::Ball;
 use serde::{Deserialize, Serialize};
 
-pub const MAX_JUMPS: f32 = 2.0;
-
 pub fn extract_loaded_params(
 	mut cmds: Commands,
 	params_assets: Res<Assets<PlayerParams>>,

--- a/rs/src/ui/dbg_ui.rs
+++ b/rs/src/ui/dbg_ui.rs
@@ -43,7 +43,7 @@ pub fn plugin(app: &mut App) -> &mut App {
 					History::<Fps>::track_resource
 						.after(update_fps)
 						.before(dbg_fps),
-					dbg_fps.run_if(dbg_window_toggled(true, KeyCode::F)),
+					dbg_fps.run_if(dbg_window_toggled(true, KeyCode::T)),
 					dbg_res::<DayNightCycle>
 						.run_if(dbg_window_toggled(true, KeyCode::N))
 						.after(dbg_fps),

--- a/rs/src/util.rs
+++ b/rs/src/util.rs
@@ -408,7 +408,7 @@ impl<T: Clone> Prev<T> {
 	) where
 		T: Component,
 	{
-		for (id, curr, mut prev) in &mut q {
+		for (id, curr, prev) in &mut q {
 			if let Some(mut prev) = prev {
 				**prev = curr.clone();
 			} else {

--- a/rs/src/util.rs
+++ b/rs/src/util.rs
@@ -396,3 +396,28 @@ impl<T: Sub<Output = D> + Clone, D> Diff for &T {
 		(*self).clone() - (*rhs).clone()
 	}
 }
+
+#[derive(Component, Resource, Deref, DerefMut)]
+pub struct Prev<T>(T);
+
+impl<T: Clone> Prev<T> {
+	pub fn update_component(mut cmds: Commands, mut q: Query<(Entity, &T, Option<&mut Self>), Changed<T>>) where T: Component {
+		for (id, curr, mut prev) in &mut q {
+			if let Some(mut prev) = prev {
+				**prev = curr.clone();
+			} else {
+				cmds.entity(id).insert(Self(curr.clone()));
+			}
+		}
+	}
+	
+	pub fn update_res(mut cmds: Commands, curr: Res<T>, prev: Option<ResMut<Self>>) where T: Resource {
+		if curr.is_changed() {
+			if let Some(mut prev) = prev {
+				**prev = curr.clone();
+			} else {
+				cmds.insert_resource(Self(curr.clone()));
+			}
+		}
+	}
+}


### PR DESCRIPTION
Moves ability code into a separate `abilities` module, rather than `input`, adds a dash ability, and replaces `leafwing_abilities` with my own design. `leafwing_abilities` is a decent crate for its purpose, but the way I want my abilities to work is not quite identical to its design. The movement abilities are currently based on a `fuel` system so that jumping and dashing share the same limited resource.