### PR TITLE
Seedable terrain

### DIFF
--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -3093,7 +3093,7 @@ checksum = "9ba869e17168793186c10ca82c7079a4ffdeac4f1a7d9e755b9491c028180e40"
 dependencies = [
  "num-traits",
  "rand 0.7.3",
- "rand_xorshift",
+ "rand_xorshift 0.2.0",
 ]
 
 [[package]]
@@ -3700,6 +3700,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "range-alloc"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4121,6 +4130,7 @@ dependencies = [
  "bevy_pkv",
  "bevy_rapier3d",
  "bimap",
+ "bytemuck",
  "colored",
  "egui_plot",
  "fixedbitset",
@@ -4131,6 +4141,7 @@ dependencies = [
  "num-traits",
  "ordered-float",
  "rand 0.8.5",
+ "rand_xorshift 0.3.0",
  "rapier3d",
  "ron",
  "serde",

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -1299,6 +1299,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
+
+[[package]]
 name = "bindgen"
 version = "0.69.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2473,9 +2479,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -3490,7 +3496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
 ]
 
 [[package]]
@@ -4113,6 +4119,7 @@ dependencies = [
  "bevy_kira_audio",
  "bevy_pkv",
  "bevy_rapier3d",
+ "bimap",
  "colored",
  "egui_plot",
  "fixedbitset",
@@ -4418,7 +4425,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "toml_datetime",
  "winnow",
 ]
@@ -4429,7 +4436,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "toml_datetime",
  "winnow",
 ]

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -4112,6 +4112,7 @@ name = "sond-has"
 version = "0.1.0"
 dependencies = [
  "array-init",
+ "base64 0.21.7",
  "bevy",
  "bevy-inspector-egui",
  "bevy_common_assets",
@@ -4129,6 +4130,7 @@ dependencies = [
  "noise",
  "num-traits",
  "ordered-float",
+ "rand 0.8.5",
  "rapier3d",
  "ron",
  "serde",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -76,6 +76,7 @@ bevy_pkv = "0.9.0" # settings
 crossbeam = "0.8.2"
 fixedbitset = "0.4.2" # navigation graph edge storage
 futures-lite = "2.1.0" # especially for `yield_now()`
+bimap = "0.6.3"
 nanorand = { version = "0.7.0", default-features = false, features = ["std", "wyrand", "getrandom"] } # wasm is broken without std and getrandom
 noise = "0.8.2"
 num-traits = "0.2.17"
@@ -108,6 +109,7 @@ array-init = { workspace = true }
 bevy_pkv = { workspace = true }
 fixedbitset = { workspace = true }
 futures-lite = { workspace = true }
+bimap = { workspace = true }
 nanorand = { workspace = true }
 noise = { workspace = true }
 num-traits = { workspace = true }

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -74,6 +74,7 @@ bevy_common_assets = { version = "0.8.0", features = ["ron"] }
 array-init = "2.1.0"
 base64 = "0.21.7"
 bevy_pkv = "0.9.0" # settings
+bytemuck = "1.14.1" # mostly for seeds
 crossbeam = "0.8.2"
 fixedbitset = "0.4.2" # navigation graph edge storage
 futures-lite = "2.1.0" # especially for `yield_now()`
@@ -83,6 +84,7 @@ noise = "0.8.2"
 num-traits = "0.2.17"
 ordered-float = "4.2.0"
 rand = "0.8.5"
+rand_xorshift = "0.3.0"
 ron = "0.8.1"
 static_assertions = "1.1.0"
 serde = "1"
@@ -110,6 +112,7 @@ bevy_common_assets = { workspace = true }
 array-init = { workspace = true }
 base64 = { workspace = true }
 bevy_pkv = { workspace = true }
+bytemuck = { workspace = true }
 fixedbitset = { workspace = true }
 futures-lite = { workspace = true }
 bimap = { workspace = true }
@@ -118,6 +121,7 @@ noise = { workspace = true }
 num-traits = { workspace = true }
 ordered-float = { workspace = true }
 rand = { workspace = true }
+rand_xorshift = { workspace = true }
 ron = { workspace = true }
 static_assertions = { workspace = true }
 serde = { workspace = true }

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -72,6 +72,7 @@ bevy_common_assets = { version = "0.8.0", features = ["ron"] }
 
 # Util
 array-init = "2.1.0"
+base64 = "0.21.7"
 bevy_pkv = "0.9.0" # settings
 crossbeam = "0.8.2"
 fixedbitset = "0.4.2" # navigation graph edge storage
@@ -81,6 +82,7 @@ nanorand = { version = "0.7.0", default-features = false, features = ["std", "wy
 noise = "0.8.2"
 num-traits = "0.2.17"
 ordered-float = "4.2.0"
+rand = "0.8.5"
 ron = "0.8.1"
 static_assertions = "1.1.0"
 serde = "1"
@@ -106,6 +108,7 @@ bevy_common_assets = { workspace = true }
 
 # Util
 array-init = { workspace = true }
+base64 = { workspace = true }
 bevy_pkv = { workspace = true }
 fixedbitset = { workspace = true }
 futures-lite = { workspace = true }
@@ -114,6 +117,7 @@ nanorand = { workspace = true }
 noise = { workspace = true }
 num-traits = { workspace = true }
 ordered-float = { workspace = true }
+rand = { workspace = true }
 ron = { workspace = true }
 static_assertions = { workspace = true }
 serde = { workspace = true }

--- a/rs/assets/shaders/dist_dither.wgsl
+++ b/rs/assets/shaders/dist_dither.wgsl
@@ -36,7 +36,7 @@ fn fragment(
 	let world_dist = length(view.world_position.xyz - in.world_position.xyz);
 	let uv = in.position.xy / 16.0;
 	let thresh = textureSample(matrix_texture, matrix_sampler, uv).x;
-	let d = max(0.0, world_dist - material.start);
+	let d = world_dist - material.start;
 	let range = material.end - material.start;
 	if d > thresh * range {
 		discard;

--- a/rs/assets/shaders/dist_dither.wgsl
+++ b/rs/assets/shaders/dist_dither.wgsl
@@ -1,0 +1,76 @@
+#import bevy_pbr::{
+	pbr_fragment::pbr_input_from_standard_material,
+	pbr_functions::{alpha_discard, calculate_view},
+	mesh_view_bindings::view,
+}
+
+#ifdef PREPASS_PIPELINE
+#import bevy_pbr::{
+    prepass_io::{VertexOutput, FragmentOutput},
+    pbr_deferred_functions::deferred_output,
+}
+#else
+#import bevy_pbr::{
+    forward_io::{VertexOutput, FragmentOutput},
+    pbr_functions::{apply_pbr_lighting, main_pass_post_lighting_processing},
+}
+#endif
+
+struct DistanceDither {
+	start: f32,
+	end: f32,
+};
+
+@group(1) @binding(100)
+var<uniform> material: DistanceDither;
+@group(1) @binding(101)
+var matrix_texture: texture_2d<f32>;
+@group(1) @binding(102)
+var matrix_sampler: sampler;
+
+@fragment
+fn fragment(
+	in: VertexOutput,
+	@builtin(front_facing) is_front: bool,
+) -> FragmentOutput {
+	let world_dist = length(view.world_position.xyz - in.world_position.xyz);
+	let uv = in.position.xy / 16.0;
+	let thresh = textureSample(matrix_texture, matrix_sampler, uv).x;
+	let d = max(0.0, world_dist - material.start);
+	let range = material.end - material.start;
+	if d > thresh * range {
+		discard;
+	}
+
+	// --- Modified from bevy extended_material example ---
+
+	// generate a PbrInput struct from the StandardMaterial bindings
+	var pbr_input = pbr_input_from_standard_material(in, is_front);
+
+	// we can optionally modify the input before lighting and alpha_discard is applied
+	pbr_input.material.base_color.b = pbr_input.material.base_color.r;
+
+	// alpha discard
+	pbr_input.material.base_color = alpha_discard(pbr_input.material, pbr_input.material.base_color);
+
+#ifdef PREPASS_PIPELINE
+	// in deferred mode we can't modify anything after that, as lighting is run in a separate fullscreen shader.
+	let out = deferred_output(in, pbr_input);
+#else
+	var out: FragmentOutput;
+	// apply lighting
+	out.color = apply_pbr_lighting(pbr_input);
+
+//	// we can optionally modify the lit color before post-processing is applied
+//	out.color = vec4<f32>(vec4<u32>(out.color * f32(my_extended_material.quantize_steps))) / f32(my_extended_material.quantize_steps);
+
+	// apply in-shader post processing (fog, alpha-premultiply, and also tonemapping, debanding if the camera is non-hdr)
+	// note this does not include fullscreen postprocessing effects like bloom.
+	out.color = main_pass_post_lighting_processing(pbr_input, out.color);
+
+//	// we can optionally modify the final result here
+//	out.color = out.color * 2.0;
+#endif
+
+	return out;
+}

--- a/rs/assets/shaders/dist_dither.wgsl.meta
+++ b/rs/assets/shaders/dist_dither.wgsl.meta
@@ -1,0 +1,7 @@
+(
+    meta_format_version: "1.0",
+    asset: Load(
+        loader: "bevy_render::render_resource::shader::ShaderLoader",
+        settings: (),
+    ),
+)

--- a/rs/assets/shaders/terrain.mat.ron
+++ b/rs/assets/shaders/terrain.mat.ron
@@ -1,0 +1,8 @@
+ExtendedMaterial(
+    extension: DistanceDither( ),
+    base: StandardMaterial(
+        base_color: Rgba ( red: 0.1, green: 0.1, blue: 0.1, alpha: 1.0),
+        reflectance: 0.3,
+        perceptual_roughness: 0.0,
+    ),
+)

--- a/rs/assets/shaders/terrain.mat.ron.meta
+++ b/rs/assets/shaders/terrain.mat.ron.meta
@@ -1,0 +1,7 @@
+(
+    meta_format_version: "1.0",
+    asset: Load(
+        loader: "sond_has::util::RonReflectAssetLoader<bevy_pbr::extended_material::ExtendedMaterial<bevy_pbr::pbr_material::StandardMaterial, sond_has::mats::DistanceDither>>",
+        settings: (),
+    ),
+)

--- a/rs/assets/tune/player_params.ron
+++ b/rs/assets/tune/player_params.ron
@@ -14,8 +14,8 @@
 		max_speed: 48.0,
 		accel: 3.0,
 		gravity: 48.0,
-		climb_angle: Deg(59.0),
-		slide_angle: Deg(59.0),
+		climb_angle: Deg(44.0),
+		slide_angle: Deg(44.0),
 		hover_height: 2.0,
 		collider: (
 			radius: 1.2,

--- a/rs/src/anim.rs
+++ b/rs/src/anim.rs
@@ -22,6 +22,8 @@ impl Plugin for BuiltinAnimations {
 		app.add_plugins((
 			AnimationPlugin::<Transform>::PLUGIN,
 			AnimationPlugin::<GlobalTransform>::PLUGIN,
+			AnimationPlugin::<Visibility>::PLUGIN,
+			AnimationPlugin::<ViewVisibility>::PLUGIN,
 		))
 		.add_systems(
 			PostUpdate,

--- a/rs/src/anim.rs
+++ b/rs/src/anim.rs
@@ -52,10 +52,8 @@ impl<T: Component> Plugin for AnimationPlugin<T> {
 	fn build(&self, app: &mut App) {
 		app.add_event::<ComponentDelta<T>>().add_systems(
 			PostUpdate,
-			(
-				DynAnimation::<T>::animate.before(apply_animations::<T>),
-				apply_animations::<T>,
-			)
+			(DynAnimation::<T>::animate, apply_animations::<T>)
+				.chain()
 				.in_set(AnimationSet::<T>::default()),
 		);
 	}

--- a/rs/src/bayer16.png
+++ b/rs/src/bayer16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:078abc20c1e0d4fad664946e5e2c7eab3c61e658061ffa7cfaa1080b6a822d22
+size 805

--- a/rs/src/enemies/dummy.rs
+++ b/rs/src/enemies/dummy.rs
@@ -1,15 +1,24 @@
 use super::enemy::Dummy;
-use crate::util::{consume_spawn_events, Spawnable};
+use crate::{
+	anim::{ComponentDelta, StartAnimation},
+	player::abilities::{Hurt, Sfx},
+	util::{consume_spawn_events, Spawnable},
+	Alive,
+};
 use bevy::{
 	ecs::system::{EntityCommands, SystemParamItem},
 	prelude::*,
 };
+use bevy_kira_audio::Audio;
 use bevy_rapier3d::{
+	dynamics::LockedAxes,
 	math::Vect,
-	prelude::{Collider, RigidBody, TransformInterpolation},
+	na::Vector3,
+	plugin::RapierContext,
+	prelude::{Collider, RigidBody, TOIStatus, TransformInterpolation},
 };
-use enum_components::EntityEnumCommands;
-use std::time::Duration;
+use enum_components::{ERef, EntityEnumCommands};
+use std::{f32::consts::FRAC_PI_2, time::Duration};
 
 pub fn plugin(app: &mut App) -> &mut App {
 	app.add_systems(Startup, setup)
@@ -18,7 +27,7 @@ pub fn plugin(app: &mut App) -> &mut App {
 			Duration::from_secs(15),
 			TimerMode::Repeating,
 		)))
-		.add_systems(Update, consume_spawn_events::<Dummy>)
+		.add_systems(Update, (consume_spawn_events::<Dummy>, handle_hits))
 		.add_systems(Last, spawn_new_dummies)
 }
 
@@ -37,10 +46,12 @@ fn setup(
 	);
 	let material = materials.add(Color::YELLOW.into());
 	let collider = Collider::capsule(Vect::NEG_Y * 2.0, Vect::Y * 2.0, 2.0);
+	let locked_axes = LockedAxes::ROTATION_LOCKED;
 	cmds.insert_resource(DummyTemplate {
 		mesh,
 		material,
 		collider,
+		locked_axes,
 	});
 }
 
@@ -50,6 +61,8 @@ struct DummyBundle {
 	body: RigidBody,
 	collider: Collider,
 	interp: TransformInterpolation,
+	locked_axes: LockedAxes,
+	alive: Alive,
 }
 
 impl Spawnable for Dummy {
@@ -65,6 +78,7 @@ impl Spawnable for Dummy {
 			mesh,
 			material,
 			collider,
+			locked_axes,
 		} = params.clone();
 		let mut cmds = cmds.spawn(DummyBundle {
 			mat_mesh: MaterialMeshBundle {
@@ -74,6 +88,7 @@ impl Spawnable for Dummy {
 				..default()
 			},
 			collider,
+			locked_axes,
 			..default()
 		});
 		cmds.set_enum(Dummy);
@@ -86,6 +101,7 @@ pub struct DummyTemplate {
 	mesh: Handle<Mesh>,
 	material: Handle<StandardMaterial>,
 	collider: Collider,
+	locked_axes: LockedAxes,
 }
 
 #[derive(Event, Default, Debug, Clone)]
@@ -101,10 +117,56 @@ pub fn spawn_new_dummies(
 	timer.tick(t.delta());
 	if timer.just_finished() {
 		events.send(NewDummy {
-			transform: Transform::default(),
+			transform: Transform {
+				rotation: Quat::from_rotation_x(FRAC_PI_2),
+				..default()
+			},
 		});
 	}
 }
 
 #[derive(Resource, Debug, Deref, DerefMut)]
 pub struct DummySpawnTimer(Timer);
+
+pub fn handle_hits(
+	mut ctx: ResMut<RapierContext>,
+	mut cmds: Commands,
+	audio: Res<Audio>,
+	sfx: Res<Sfx>,
+	dummies: Query<(Entity, &GlobalTransform), (ERef<Dummy>, With<Alive>)>,
+	mut events: EventReader<Hurt>,
+) {
+	for event in events.read() {
+		if let Ok((id, global)) = dummies.get(event.victim) {
+			let Some(toi) = event.toi.details else {
+				continue;
+			};
+			if let Some(body) = ctx
+				.entity2body()
+				.get(&id)
+				.copied()
+				.and_then(|body| ctx.bodies.get_mut(body))
+			{
+				body.set_locked_axes(rapier3d::prelude::LockedAxes::empty(), true);
+				body.apply_impulse_at_point(
+					Vector3::from(global.compute_transform().rotation * toi.normal2) * 2000.0,
+					toi.witness1.into(),
+					true,
+				);
+			}
+			let mut cmds = cmds.entity(id);
+			cmds.insert(LockedAxes::empty());
+			cmds.remove::<Alive>();
+			let mut timer = Timer::from_seconds(4.0, TimerMode::Once);
+			// Just need to animate some component. Don't lock mutable access to transforms for this.
+			cmds.start_animation::<Visibility>(move |id, _, t, mut ctrl| {
+				timer.tick(t.delta());
+				if timer.finished() {
+					ctrl.commands().entity(id).despawn();
+					ctrl.end();
+				}
+				ComponentDelta::indefinite(id, |_| ())
+			});
+		}
+	}
+}

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -3,11 +3,10 @@
 	windows_subsystem = "windows"
 )]
 
-use crate::mats::BubbleMaterial;
+use crate::mats::MatsPlugin;
 use bevy::{
 	diagnostic::FrameTimeDiagnosticsPlugin,
 	ecs::schedule::{LogLevel, ScheduleBuildSettings},
-	pbr::ExtendedMaterial,
 	prelude::*,
 	render::RenderPlugin,
 	window::PrimaryWindow,
@@ -18,7 +17,7 @@ use bevy_rapier3d::prelude::*;
 use particles::{ParticlesPlugin, Spewer};
 use player::ctrl::CtrlVel;
 use std::{f32::consts::*, fmt::Debug, time::Duration};
-use util::{IntoFnPlugin, RonReflectAssetLoader};
+use util::IntoFnPlugin;
 
 #[allow(unused_imports, clippy::single_component_path_imports)]
 #[cfg(all(debug_assertions, not(target_arch = "wasm32")))]
@@ -111,10 +110,13 @@ pub fn game_plugin(app: &mut App) -> &mut App {
 		RapierPhysicsPlugin::<()>::default().in_schedule(Update),
 		FrameTimeDiagnosticsPlugin,
 		AudioPlugin,
+	))
+	.add_plugins((
 		ParticlesPlugin,
 		AbilitiesPlugin,
 		OffloadingPlugin,
 		SkyPlugin,
+		MatsPlugin,
 		anim::BuiltinAnimations,
 		anim::AnimationPlugin::<Spewer>::PLUGIN,
 		enemies::plugin.plugfn(),
@@ -125,26 +127,13 @@ pub fn game_plugin(app: &mut App) -> &mut App {
 		ui::plugin.plugfn(),
 	))
 	.insert_resource(PkvStore::new_with_qualifier("studio", "sonday", "has"))
-	.add_plugins((MaterialPlugin::<
-		ExtendedMaterial<StandardMaterial, BubbleMaterial>,
-	>::default(),))
 	.add_systems(Startup, startup)
 	.add_systems(
 		Update,
 		(terminal_velocity.before(StepSimulation), fullscreen),
 	)
 	.add_systems(PostUpdate, (despawn_oob,));
-	type BubbleMatExt = ExtendedMaterial<StandardMaterial, BubbleMaterial>;
-	let registry = app.world.get_resource::<AppTypeRegistry>().unwrap().clone();
-	{
-		let mut reg = registry.write();
-		reg.register::<BubbleMaterial>();
-		reg.register::<BubbleMatExt>();
-	}
-	app.register_asset_loader(RonReflectAssetLoader::<BubbleMatExt>::new(
-		registry,
-		vec!["mat.ron"],
-	));
+
 	app
 }
 

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -289,3 +289,6 @@ fn fullscreen(kb: Res<Input<KeyCode>>, mut windows: Query<&mut Window, With<Prim
 		};
 	}
 }
+
+#[derive(Component, Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Reflect)]
+pub struct Alive;

--- a/rs/src/mats.rs
+++ b/rs/src/mats.rs
@@ -16,7 +16,7 @@ use bevy::{
 };
 use serde::{Deserialize, Serialize};
 
-pub type StdMatExt<T: MaterialExtension> = ExtendedMaterial<StandardMaterial, T>;
+pub type StdMatExt<T> = ExtendedMaterial<StandardMaterial, T>;
 
 pub struct MatsPlugin;
 

--- a/rs/src/mats.rs
+++ b/rs/src/mats.rs
@@ -1,10 +1,78 @@
+use crate::{
+	planet::chunks::{CHUNK_COLS, CHUNK_SCALE, TERRAIN_CELL_SIZE},
+	util::RonReflectAssetLoader,
+};
 use bevy::{
-	pbr::MaterialExtension,
+	asset::load_internal_binary_asset,
+	pbr::{ExtendedMaterial, MaterialExtension},
 	prelude::*,
 	reflect::TypeUuid,
-	render::render_resource::{AsBindGroup, ShaderRef},
+	render::{
+		render_resource::{AsBindGroup, ShaderRef},
+		texture::{
+			ImageAddressMode, ImageFilterMode, ImageSampler, ImageSamplerDescriptor, ImageType,
+		},
+	},
 };
 use serde::{Deserialize, Serialize};
+
+pub type StdMatExt<T: MaterialExtension> = ExtendedMaterial<StandardMaterial, T>;
+
+pub struct MatsPlugin;
+
+impl Plugin for MatsPlugin {
+	fn build(&self, app: &mut App) {
+		app.add_plugins((
+			MaterialPlugin::<StdMatExt<BubbleMaterial>>::default(),
+			MaterialPlugin::<StdMatExt<DistanceDither>>::default(),
+		));
+
+		let registry = app.world.get_resource::<AppTypeRegistry>().unwrap().clone();
+		{
+			let mut reg = registry.write();
+			reg.register::<BubbleMaterial>();
+			reg.register::<StdMatExt<BubbleMaterial>>();
+			reg.register::<DistanceDither>();
+			reg.register::<StdMatExt<DistanceDither>>();
+		}
+		app.register_asset_loader(RonReflectAssetLoader::<StdMatExt<BubbleMaterial>>::new(
+			registry.clone(),
+			vec!["mat.ron"],
+		))
+		.register_asset_loader(RonReflectAssetLoader::<StdMatExt<DistanceDither>>::new(
+			registry,
+			vec!["mat.ron"],
+		));
+	}
+
+	fn finish(&self, app: &mut App) {
+		let mut assets = app.world.resource_mut::<Assets<Image>>();
+
+		let image = Image::from_buffer(
+			include_bytes!("bayer16.png").as_ref(),
+			ImageType::Extension("png"),
+			default(),
+			false,
+			ImageSampler::Descriptor(ImageSamplerDescriptor {
+				label: None,
+				address_mode_u: ImageAddressMode::Repeat,
+				address_mode_v: ImageAddressMode::Repeat,
+				address_mode_w: ImageAddressMode::ClampToEdge,
+				mag_filter: ImageFilterMode::Nearest,
+				min_filter: ImageFilterMode::Nearest,
+				mipmap_filter: ImageFilterMode::Nearest,
+				lod_min_clamp: 0.0,
+				lod_max_clamp: 0.0,
+				compare: None,
+				anisotropy_clamp: 1,
+				border_color: None,
+			}),
+		)
+		.unwrap();
+
+		assets.insert(BAYER_HANDLE, image);
+	}
+}
 
 #[derive(Asset, AsBindGroup, Debug, Clone, TypeUuid, Serialize, Deserialize, Reflect)]
 #[reflect(Default)]
@@ -30,4 +98,40 @@ impl MaterialExtension for BubbleMaterial {
 	// fn vertex_shader() -> ShaderRef {
 	// 	"shaders/bubble.wgsl".into()
 	// }
+}
+
+#[derive(Asset, AsBindGroup, Debug, Clone, TypeUuid, Serialize, Deserialize, Reflect)]
+#[reflect(Default)]
+#[uuid = "ff77386c-1d31-4afd-b52f-481b0845de0d"]
+pub struct DistanceDither {
+	#[uniform(100)]
+	pub start: f32,
+	#[uniform(100)]
+	pub end: f32,
+
+	#[serde(skip)]
+	#[texture(101)]
+	#[sampler(102)]
+	pub matrix: Handle<Image>,
+}
+
+impl DistanceDither {
+	pub fn new(start: f32, end: f32, matrix: Handle<Image>) -> Self {
+		Self { start, end, matrix }
+	}
+}
+
+pub const BAYER_HANDLE: Handle<Image> =
+	Handle::weak_from_u128(92299220200241619468604683494190943784);
+
+impl Default for DistanceDither {
+	fn default() -> Self {
+		Self::new(CHUNK_SCALE.x, CHUNK_SCALE.x * 2.0, BAYER_HANDLE.clone())
+	}
+}
+
+impl MaterialExtension for DistanceDither {
+	fn fragment_shader() -> ShaderRef {
+		"shaders/dist_dither.wgsl".into()
+	}
 }

--- a/rs/src/planet.rs
+++ b/rs/src/planet.rs
@@ -1,8 +1,9 @@
+use std::any::Any;
 use crate::{planet::day_night::DayNightCycle, util::IntoFnPlugin};
 use bevy::prelude::*;
 use bevy_rapier3d::na::{Vector2, Vector3};
 use serde::{Deserialize, Serialize};
-use std::ops::{Add, Sub};
+use std::ops::{Add, Deref, DerefMut, Sub};
 use crate::planet::chunks::{ChunkIndex, LoadedChunks};
 use crate::planet::frame::PlanetFramePlugin;
 use crate::util::Diff;
@@ -20,12 +21,50 @@ pub fn plugin(app: &mut App) -> &mut App {
 		.init_resource::<LoadedChunks>()
 }
 
-#[derive(Default, Debug, Copy, Clone, Deref, DerefMut, PartialEq, Serialize, Deserialize)]
-pub struct PlanetVec3(pub Vector3<f64>);
+#[derive(Default, Debug, Copy, Clone, PartialEq, Serialize, Deserialize, Reflect,)]
+#[repr(C)]
+pub struct PlanetVec3 {
+	x: f64,
+	y: f64,
+	z: f64,
+}
 
 impl PlanetVec3 {
 	pub fn new(x: f64, y: f64, z: f64) -> Self {
-		Self(Vector3::new(x, y, z))
+		Self::from(Vector3::new(x, y, z))
+	}
+}
+
+impl From<Vector3<f64>> for PlanetVec3 {
+	#[inline(always)]
+	fn from(value: Vector3<f64>) -> Self {
+		Self {
+			x: value.x,
+			y: value.y,
+			z: value.z,
+		}
+	}
+}
+
+impl From<Vec3> for PlanetVec3 {
+	fn from(value: Vec3) -> Self {
+		Self::from(Vector3::new(value.x as f64, value.y as f64, value.z as f64))
+	}
+}
+
+impl Deref for PlanetVec3 {
+	type Target = Vector3<f64>;
+	
+	fn deref(&self) -> &Self::Target {
+		// SAFETY: Vector3 is `#[repr(C)]` and transmutes to `XY<T> { x: T, y: T, z: T } in `nalgebra::coordinates`
+		unsafe { &*(self as *const Self as *const _) }
+	}
+}
+
+impl DerefMut for PlanetVec3 {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		// SAFETY: Vector3 is `#[repr(C)]` and transmutes to `XY<T> { x: T, y: T, z: T } in `nalgebra::coordinates`
+		unsafe { &mut *(self as *mut Self as *mut _) }
 	}
 }
 
@@ -34,12 +73,6 @@ impl Diff for PlanetVec3 {
 	
 	fn delta_from(&self, rhs: &Self) -> Self::Delta {
 		(*self - *rhs).into()
-	}
-}
-
-impl From<Vec3> for PlanetVec3 {
-	fn from(value: Vec3) -> Self {
-		Self(Vector3::new(value.x as f64, value.y as f64, value.z as f64))
 	}
 }
 
@@ -57,7 +90,7 @@ impl Add<PlanetVec3> for PlanetVec3 {
 	type Output = Self;
 
 	fn add(self, rhs: Self) -> Self::Output {
-		Self(*self + *rhs)
+		Self::from(*self + *rhs)
 	}
 }
 
@@ -66,7 +99,7 @@ impl Add<Vec3> for PlanetVec3 {
 
 	fn add(self, rhs: Vec3) -> Self::Output {
 		let rhs = Vector3::new(rhs.x as f64, rhs.y as f64, rhs.z as f64);
-		Self(*self + rhs)
+		Self::from(*self + rhs)
 	}
 }
 
@@ -74,7 +107,7 @@ impl Sub<PlanetVec3> for PlanetVec3 {
 	type Output = Self;
 
 	fn sub(self, rhs: Self) -> Self::Output {
-		Self(*self - *rhs)
+		Self::from(*self - *rhs)
 	}
 }
 
@@ -83,18 +116,48 @@ impl Sub<Vec3> for PlanetVec3 {
 
 	fn sub(self, rhs: Vec3) -> Self::Output {
 		let rhs = Vector3::new(rhs.x as f64, rhs.y as f64, rhs.z as f64);
-		Self(*self - rhs)
+		Self::from(*self - rhs)
 	}
 }
 
 #[derive(
-	Component, Default, Debug, Copy, Clone, Deref, DerefMut, PartialEq, Serialize, Deserialize,
+	Component, Default, Debug, Copy, Clone, PartialEq, Serialize, Deserialize, Reflect,
 )]
-pub struct PlanetVec2(pub Vector2<f64>);
+#[repr(C)]
+pub struct PlanetVec2 {
+	x: f64,
+	y: f64,
+}
+
+impl Deref for PlanetVec2 {
+	type Target = Vector2<f64>;
+	
+	fn deref(&self) -> &Self::Target {
+		// SAFETY: Vector2 is `#[repr(C)]` and transmutes to `XY<T> { x: T, y: T } in `nalgebra::coordinates`
+		unsafe { &*(self as *const Self as *const _) }
+	}
+}
+
+impl DerefMut for PlanetVec2 {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		// SAFETY: Vector2 is `#[repr(C)]` and transmutes to `XY<T> { x: T, y: T } in `nalgebra::coordinates`
+		unsafe { &mut *(self as *mut Self as *mut _) }
+	}
+}
+
+impl From<Vector2<f64>> for PlanetVec2 {
+	#[inline(always)]
+	fn from(value: Vector2<f64>) -> Self {
+		Self {
+			x: value.x,
+			y: value.y,
+		}
+	}
+}
 
 impl PlanetVec2 {
 	pub fn new(x: f64, y: f64) -> Self {
-		Self(Vector2::new(x, y))
+		Self { x, y }
 	}
 
 	pub fn closest_chunk(self) -> ChunkIndex {
@@ -112,7 +175,7 @@ impl Diff for PlanetVec2 {
 
 impl From<Vec2> for PlanetVec2 {
 	fn from(value: Vec2) -> Self {
-		Self(Vector2::new(value.x as f64, value.y as f64))
+		Self { x: value.x as f64, y: value.y as f64 }
 	}
 }
 
@@ -129,7 +192,7 @@ impl Add<PlanetVec2> for PlanetVec2 {
 	type Output = Self;
 
 	fn add(self, rhs: Self) -> Self::Output {
-		Self(*self + *rhs)
+		Self::from(*self + *rhs)
 	}
 }
 
@@ -138,7 +201,7 @@ impl Add<Vec2> for PlanetVec2 {
 
 	fn add(self, rhs: Vec2) -> Self::Output {
 		let rhs = Vector2::new(rhs.x as f64, rhs.y as f64);
-		Self(*self + rhs)
+		Self::from(*self + rhs)
 	}
 }
 
@@ -146,7 +209,7 @@ impl Sub<PlanetVec2> for PlanetVec2 {
 	type Output = Self;
 
 	fn sub(self, rhs: Self) -> Self::Output {
-		Self(*self - *rhs)
+		Self::from(*self - *rhs)
 	}
 }
 
@@ -155,6 +218,6 @@ impl Sub<Vec2> for PlanetVec2 {
 
 	fn sub(self, rhs: Vec2) -> Self::Output {
 		let rhs = Vector2::new(rhs.x as f64, rhs.y as f64);
-		Self(*self - rhs)
+		Self::from(*self - rhs)
 	}
 }

--- a/rs/src/planet.rs
+++ b/rs/src/planet.rs
@@ -234,289 +234,140 @@ impl Sub<Vec2> for PlanetVec2 {
 }
 
 pub mod seeds {
-	use crate::planet::terrain;
-	use base64::{engine::general_purpose::URL_SAFE, prelude::*, DecodeError, DecodeSliceError};
+	use base64::{engine::general_purpose::URL_SAFE, prelude::*, DecodeSliceError};
 	use bevy::{
-		log::{error, trace, warn},
 		prelude::Resource,
+		utils::{AHasher, RandomState},
 	};
-	use rand::random;
-	use std::fmt::{Display, Formatter};
+	use rand::{distributions::Standard, prelude::Distribution, Rng};
+	use std::{
+		borrow::Cow,
+		fmt::{Display, Formatter},
+		hash::{BuildHasher, Hash, Hasher},
+	};
 
-	#[derive(Resource, Debug, Copy, Clone, Default, PartialEq, Eq, Hash)]
-	#[repr(C)]
+	#[derive(Resource, Debug, Clone)]
 	pub struct PlanetSeed {
-		pub tera: TerrainSeeds,
+		string: Cow<'static, str>,
+		hash: [u8; 24],
 	}
 
-	impl PlanetSeed {
-		pub const BASE64_CHARS: usize = TerrainSeeds::BASE64_CHARS;
-
-		pub fn base64(self) -> [u8; Self::BASE64_CHARS] {
-			self.tera.base64()
+	impl PartialEq for PlanetSeed {
+		fn eq(&self, other: &Self) -> bool {
+			self.hash == other.hash
 		}
+	}
 
-		pub fn from_base64(bytes: impl AsRef<[u8]>) -> Result<Self, DecodeError> {
-			TerrainSeeds::from_base64(bytes.as_ref()).map(|(tera, rest)| {
-				if rest.len() > 0 {
-					warn!(
-						"Undecoded base64 characters: {}",
-						String::from_utf8_lossy(rest)
-					);
-				}
-				Self { tera }
-			})
+	impl Distribution<PlanetSeed> for Standard {
+		fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> PlanetSeed {
+			let hash = rng.gen::<[u8; 24]>();
+			let string = Cow::from(URL_SAFE.encode(hash));
+
+			PlanetSeed { string, hash }
+		}
+	}
+
+	impl<S: Into<Cow<'static, str>>> From<S> for PlanetSeed {
+		fn from(value: S) -> Self {
+			let string = value.into();
+			let bytes = string.as_bytes();
+			let bytes = if bytes.len() > Self::MAX_INPUT_LEN {
+				bytes.split_at(Self::MAX_INPUT_LEN).0
+			} else {
+				bytes
+			};
+
+			let mut hash = [0u8; 24];
+
+			// Randomly generated during development.
+			// WARNING: Changing these will break compatibility with older seeds.
+			let mut hasher = RandomState::with_seeds(
+				8171301572015878809,
+				11868435174398743204,
+				12156415504192146545,
+				13548443979666687785,
+			)
+			.build_hasher();
+			hasher.write(bytes);
+			hash[0..8].copy_from_slice(&hasher.finish().to_le_bytes());
+
+			hasher.write(bytes);
+			hash[8..16].copy_from_slice(&hasher.finish().to_le_bytes());
+
+			hasher.write(bytes);
+			hash[16..24].copy_from_slice(&hasher.finish().to_le_bytes());
+
+			Self { string, hash }
 		}
 	}
 
 	impl Display for PlanetSeed {
 		fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-			f.write_str(std::str::from_utf8(&self.base64()).unwrap())
+			self.string.fmt(f)
 		}
 	}
 
-	#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-	#[repr(C)]
-	pub struct TerrainSeeds {
-		pub base: u32,
-		perlin: HSSeed,
-		worley: HSSeed,
-		billow: HSSeed,
-		ridged: HSSeed,
-	}
+	impl PlanetSeed {
+		/// Maximum number of characters that will be hashed from the input string.
+		// WARNING: Changing this will break compatibility with some older seeds.
+		pub const MAX_INPUT_LEN: usize = 128;
 
-	const fn base64_chars(bytes: usize) -> usize {
-		bytes.div_ceil(3) * 4
-	}
-	const _ASSERT4: [u8; 8] = [0; base64_chars(4)];
-	const _ASSERT7: [u8; 12] = [0; base64_chars(7)];
-
-	impl TerrainSeeds {
-		/// Number of noise sources.
-		pub const LEN: u8 = 4;
-
-		/// Number of base64 characters to encode [Self::LEN].
-		pub const LEN_CHARS: usize = 4;
-		/// Number of base64 characters to encode [Self::base].
-		pub const BASE_CHARS: usize = base64_chars(4);
-		/// Number of base64 characters to encode all source seeds.
-		pub const SOURCES_CHARS: usize =
-			base64_chars(std::mem::size_of::<HSSeed>() * Self::LEN as usize);
-		/// Total number of base64 characters to encode `Self`.
-		pub const BASE64_CHARS: usize = Self::LEN_CHARS + Self::BASE_CHARS + Self::SOURCES_CHARS;
-
-		pub fn base64(&self) -> [u8; Self::BASE64_CHARS] {
-			let mut ret = [0u8; Self::BASE64_CHARS];
-
-			{
-				let (len, ret) = ret.split_at_mut(Self::LEN_CHARS);
-				URL_SAFE.encode_slice(&[Self::LEN], len).unwrap();
-				let (base, ret) = ret.split_at_mut(Self::BASE_CHARS);
-				URL_SAFE
-					.encode_slice(self.base.to_le_bytes(), base)
-					.unwrap();
-				let sources_bytes = [
-					self.perlin.bytes(),
-					self.worley.bytes(),
-					self.billow.bytes(),
-					self.ridged.bytes(),
-				];
-				let sources_bytes = unsafe {
-					std::mem::transmute::<
-						_,
-						&[u8; Self::LEN as usize * std::mem::size_of::<HSSeed>()],
-					>(&sources_bytes)
-				};
-				let n = URL_SAFE.encode_slice(sources_bytes, ret).unwrap();
-				debug_assert_eq!(n, ret.len());
-			}
-
-			ret
+		pub fn string(&self) -> &Cow<'static, str> {
+			&self.string
 		}
 
-		pub fn from_base64(bytes: &[u8]) -> Result<(Self, &[u8]), DecodeError> {
-			let (len, rest) = bytes.split_at(Self::LEN_CHARS);
-			let mut buf = [u8::MAX; 3];
-			let n = URL_SAFE.decode_slice(len, &mut buf).map_err(|e| match e {
-				DecodeSliceError::DecodeError(e) => e,
-				DecodeSliceError::OutputSliceTooSmall => unreachable!(),
-			})?;
-			debug_assert_eq!(n, 1);
-			let len = buf[0];
-			if len != Self::LEN {
-				warn!("Seed is from a different version. Making a best-effort conversion.");
-			}
+		/// Transforms self into its canonical representation, with the string being the base64
+		/// encoding of its hash.
+		pub fn canonical(mut self) -> Self {
+			self.make_canonical();
+			self
+		}
 
-			let (base, rest) = rest.split_at(Self::BASE_CHARS);
-			let mut buf = [0u8; 4];
-			let n = URL_SAFE.decode_slice_unchecked(base, &mut buf)?;
-			debug_assert_eq!(n, 4);
-			let base = u32::from_le_bytes(buf);
-
-			let sources_chars = usize::min(Self::SOURCES_CHARS, rest.len());
-			let (sources, rest) = rest.split_at(sources_chars);
-			const SOURCES_BYTES: usize = std::mem::size_of::<HSSeed>() * TerrainSeeds::LEN as usize;
-			let mut buf = [u8::MAX; SOURCES_BYTES + 2];
-			match URL_SAFE.decode_slice(sources, &mut buf) {
-				Ok(n) => debug_assert_eq!(n, SOURCES_BYTES),
-				Err(DecodeSliceError::OutputSliceTooSmall) => unreachable!(),
-				Err(DecodeSliceError::DecodeError(e)) => return Err(e),
-			}
-			let buf = unsafe {
-				&*(&buf as *const _
-					as *const [[u8; std::mem::size_of::<HSSeed>()]; Self::LEN as usize])
+		/// Replaces the string representation of self with the canonical base64 encoding of its hash.
+		pub fn make_canonical(&mut self) {
+			let Self { string, hash } = self;
+			let mut canonical = String::with_capacity(32);
+			URL_SAFE.encode_string(hash, &mut canonical);
+			debug_assert_eq!(canonical.len(), 32);
+			if *string != canonical {
+				*string.to_mut() = canonical;
 			};
-
-			Ok((
-				Self {
-					base,
-					perlin: HSSeed::from_bytes(buf[0]),
-					worley: HSSeed::from_bytes(buf[1]),
-					billow: HSSeed::from_bytes(buf[2]),
-					ridged: HSSeed::from_bytes(buf[3]),
-				},
-				rest,
-			))
 		}
 
-		pub fn perlin(&self) -> HSSeed {
-			self.perlin
-		}
-		pub fn worley(&self) -> HSSeed {
-			self.worley
-		}
-		pub fn billow(&self) -> HSSeed {
-			self.billow
-		}
-		pub fn ridged(&self) -> HSSeed {
-			self.ridged
-		}
-	}
-
-	impl Default for TerrainSeeds {
-		fn default() -> Self {
-			let [perlin, worley, billow, ridged] = HSSeed::many_best_effort();
-			Self {
-				base: random(),
-				perlin,
-				worley,
-				billow,
-				ridged,
-			}
-		}
-	}
-
-	/// Combined heights and strength seed for [ChooseAndSmooth](terrain::noise::ChooseAndSmooth)
-	#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-	#[repr(C)]
-	pub struct HSSeed {
-		heights: u32,
-		strength: u32,
-	}
-
-	impl HSSeed {
-		/// Changing the size of `HSSeed` will break compatibility with older seeds.
-		const _ASSERT_SIZE_8: [u8; 8] = [0; std::mem::size_of::<Self>()];
-
-		pub fn try_not_clashing_with(others: &[u32], attempts: usize) -> Option<Self> {
-			let mut s = random();
-			for _ in 0..attempts {
-				if !others.contains(&s) {
-					return Some(Self {
-						heights: random(),
-						strength: s,
-					});
-				} else {
-					trace!("{} clashes with [{}]", URL_SAFE.encode(s.to_le_bytes()), {
-						let mut encoded = String::with_capacity((others.len() * 4).div_ceil(3));
-						for other in others {
-							URL_SAFE.encode_string(other.to_le_bytes(), &mut encoded);
-						}
-						encoded
-					});
-					s = random();
-				}
-			}
-			None
+		pub fn hash(&self) -> &[u8; 24] {
+			&self.hash
 		}
 
-		pub fn best_effort(others: &[u32]) -> Self {
-			const ATTEMPTS: usize = 1024;
-			Self::try_not_clashing_with(others, ATTEMPTS).unwrap_or_else(|| {
-				let s = random();
-				if others.contains(&s) {
-					let mut encoded = String::with_capacity((others.len() * 4).div_ceil(3));
-					for other in others {
-						URL_SAFE.encode_string(other.to_le_bytes(), &mut encoded);
-					}
-					error!(
-						"Couldn't find a non-clashing strength seed in {ATTEMPTS} attempts. \
-					Using {} despite it clashing with [{encoded}].",
-						URL_SAFE.encode(s.to_le_bytes())
-					);
-				} else {
-					trace!(
-						"One last attempt found {}",
-						URL_SAFE.encode(s.to_le_bytes())
-					);
-				}
-				Self {
-					heights: random(),
-					strength: s,
-				}
-			})
-		}
-
-		pub fn many_best_effort<const LEN: usize>() -> [Self; LEN] {
-			let mut ret = [Self {
-				heights: 0,
-				strength: 0,
-			}; LEN];
-			let mut buf = [0; LEN];
-			for i in 0..LEN {
-				let new = Self::best_effort(&buf[0..i]);
-				ret[i] = new;
-				buf[i] = new.strength;
-			}
-			ret
-		}
-
-		pub fn bytes(self) -> [u8; std::mem::size_of::<Self>()] {
-			unsafe {
-				// All std ways of doing this are either unstable or work with slices instead of arrays
-				std::mem::transmute([self.heights.to_le_bytes(), self.strength.to_le_bytes()])
-			}
-		}
-
-		pub fn from_bytes(bytes: [u8; std::mem::size_of::<Self>()]) -> Self {
-			let [heights, strength] = unsafe {
-				// All std ways of doing this are either unstable or work with slices instead of arrays
-				std::mem::transmute(bytes)
-			};
-			Self {
-				heights: u32::from_le_bytes(heights),
-				strength: u32::from_le_bytes(strength),
-			}
-		}
-
-		pub fn heights(&self) -> u32 {
-			self.heights
-		}
-		pub fn strength(&self) -> u32 {
-			self.strength
+		pub fn from_canonical(
+			canonical: impl Into<Cow<'static, str>>,
+		) -> Result<Self, DecodeSliceError> {
+			let string = canonical.into();
+			assert_eq!(string.len(), 32);
+			let mut hash = [0; 24];
+			URL_SAFE.decode_slice(&*string, &mut hash)?;
+			Ok(Self { string, hash })
 		}
 	}
 
 	#[cfg(test)]
 	mod tests {
-		use crate::planet::seeds::PlanetSeed;
+		use super::PlanetSeed;
 
 		#[test]
-		fn seed_base64_round_trip() {
-			let seed = PlanetSeed::default();
-			let encoded = seed.base64();
-			let decoded = PlanetSeed::from_base64(encoded);
-			assert_eq!(Ok(seed), decoded);
+		fn canonical_equivalence() {
+			let seed = PlanetSeed::from("This is a test seed for canonical equivalence.");
+			let (seed, canonical) = (seed.clone(), seed.canonical());
+			assert_ne!(seed.string, canonical.string);
+			assert_eq!(seed, canonical);
+		}
+
+		#[test]
+		fn version_equivalence() {
+			const S: &str = "This is a test seed for seed consistency across game versions";
+			const CANON: &str = "EMVUkEmSHysISOFRcpRyoTWjBDYE3IgV";
+			let seed = PlanetSeed::from(S);
+			let canonical = PlanetSeed::from_canonical(CANON).unwrap();
+			assert_eq!(seed, canonical);
 		}
 	}
 }

--- a/rs/src/planet.rs
+++ b/rs/src/planet.rs
@@ -3,14 +3,16 @@ use bevy::prelude::*;
 use bevy_rapier3d::na::{Vector2, Vector3};
 use serde::{Deserialize, Serialize};
 use std::ops::{Add, Sub};
+use crate::planet::frame::PlanetFramePlugin;
 
 pub mod chunks;
 pub mod day_night;
+pub mod frame;
 pub mod sky;
 pub mod terrain;
 
 pub fn plugin(app: &mut App) -> &mut App {
-	app.add_plugins((terrain::plugin.plugfn(), day_night::plugin.plugfn()))
+	app.add_plugins((terrain::plugin.plugfn(), day_night::plugin.plugfn(), PlanetFramePlugin))
 		.init_resource::<DayNightCycle>()
 		.register_type::<DayNightCycle>()
 }

--- a/rs/src/planet.rs
+++ b/rs/src/planet.rs
@@ -232,3 +232,291 @@ impl Sub<Vec2> for PlanetVec2 {
 		Self::from(*self - rhs)
 	}
 }
+
+pub mod seeds {
+	use crate::planet::terrain;
+	use base64::{engine::general_purpose::URL_SAFE, prelude::*, DecodeError, DecodeSliceError};
+	use bevy::{
+		log::{error, trace, warn},
+		prelude::Resource,
+	};
+	use rand::random;
+	use std::fmt::{Display, Formatter};
+
+	#[derive(Resource, Debug, Copy, Clone, Default, PartialEq, Eq, Hash)]
+	#[repr(C)]
+	pub struct PlanetSeed {
+		pub tera: TerrainSeeds,
+	}
+
+	impl PlanetSeed {
+		pub const BASE64_CHARS: usize = TerrainSeeds::BASE64_CHARS;
+
+		pub fn base64(self) -> [u8; Self::BASE64_CHARS] {
+			self.tera.base64()
+		}
+
+		pub fn from_base64(bytes: impl AsRef<[u8]>) -> Result<Self, DecodeError> {
+			TerrainSeeds::from_base64(bytes.as_ref()).map(|(tera, rest)| {
+				if rest.len() > 0 {
+					warn!(
+						"Undecoded base64 characters: {}",
+						String::from_utf8_lossy(rest)
+					);
+				}
+				Self { tera }
+			})
+		}
+	}
+
+	impl Display for PlanetSeed {
+		fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+			f.write_str(std::str::from_utf8(&self.base64()).unwrap())
+		}
+	}
+
+	#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+	#[repr(C)]
+	pub struct TerrainSeeds {
+		pub base: u32,
+		perlin: HSSeed,
+		worley: HSSeed,
+		billow: HSSeed,
+		ridged: HSSeed,
+	}
+
+	const fn base64_chars(bytes: usize) -> usize {
+		bytes.div_ceil(3) * 4
+	}
+	const _ASSERT4: [u8; 8] = [0; base64_chars(4)];
+	const _ASSERT7: [u8; 12] = [0; base64_chars(7)];
+
+	impl TerrainSeeds {
+		/// Number of noise sources.
+		pub const LEN: u8 = 4;
+
+		/// Number of base64 characters to encode [Self::LEN].
+		pub const LEN_CHARS: usize = 4;
+		/// Number of base64 characters to encode [Self::base].
+		pub const BASE_CHARS: usize = base64_chars(4);
+		/// Number of base64 characters to encode all source seeds.
+		pub const SOURCES_CHARS: usize =
+			base64_chars(std::mem::size_of::<HSSeed>() * Self::LEN as usize);
+		/// Total number of base64 characters to encode `Self`.
+		pub const BASE64_CHARS: usize = Self::LEN_CHARS + Self::BASE_CHARS + Self::SOURCES_CHARS;
+
+		pub fn base64(&self) -> [u8; Self::BASE64_CHARS] {
+			let mut ret = [0u8; Self::BASE64_CHARS];
+
+			{
+				let (len, ret) = ret.split_at_mut(Self::LEN_CHARS);
+				URL_SAFE.encode_slice(&[Self::LEN], len).unwrap();
+				let (base, ret) = ret.split_at_mut(Self::BASE_CHARS);
+				URL_SAFE
+					.encode_slice(self.base.to_le_bytes(), base)
+					.unwrap();
+				let sources_bytes = [
+					self.perlin.bytes(),
+					self.worley.bytes(),
+					self.billow.bytes(),
+					self.ridged.bytes(),
+				];
+				let sources_bytes = unsafe {
+					std::mem::transmute::<
+						_,
+						&[u8; Self::LEN as usize * std::mem::size_of::<HSSeed>()],
+					>(&sources_bytes)
+				};
+				let n = URL_SAFE.encode_slice(sources_bytes, ret).unwrap();
+				debug_assert_eq!(n, ret.len());
+			}
+
+			ret
+		}
+
+		pub fn from_base64(bytes: &[u8]) -> Result<(Self, &[u8]), DecodeError> {
+			let (len, rest) = bytes.split_at(Self::LEN_CHARS);
+			let mut buf = [u8::MAX; 3];
+			let n = URL_SAFE.decode_slice(len, &mut buf).map_err(|e| match e {
+				DecodeSliceError::DecodeError(e) => e,
+				DecodeSliceError::OutputSliceTooSmall => unreachable!(),
+			})?;
+			debug_assert_eq!(n, 1);
+			let len = buf[0];
+			if len != Self::LEN {
+				warn!("Seed is from a different version. Making a best-effort conversion.");
+			}
+
+			let (base, rest) = rest.split_at(Self::BASE_CHARS);
+			let mut buf = [0u8; 4];
+			let n = URL_SAFE.decode_slice_unchecked(base, &mut buf)?;
+			debug_assert_eq!(n, 4);
+			let base = u32::from_le_bytes(buf);
+
+			let sources_chars = usize::min(Self::SOURCES_CHARS, rest.len());
+			let (sources, rest) = rest.split_at(sources_chars);
+			const SOURCES_BYTES: usize = std::mem::size_of::<HSSeed>() * TerrainSeeds::LEN as usize;
+			let mut buf = [u8::MAX; SOURCES_BYTES + 2];
+			match URL_SAFE.decode_slice(sources, &mut buf) {
+				Ok(n) => debug_assert_eq!(n, SOURCES_BYTES),
+				Err(DecodeSliceError::OutputSliceTooSmall) => unreachable!(),
+				Err(DecodeSliceError::DecodeError(e)) => return Err(e),
+			}
+			let buf = unsafe {
+				&*(&buf as *const _
+					as *const [[u8; std::mem::size_of::<HSSeed>()]; Self::LEN as usize])
+			};
+
+			Ok((
+				Self {
+					base,
+					perlin: HSSeed::from_bytes(buf[0]),
+					worley: HSSeed::from_bytes(buf[1]),
+					billow: HSSeed::from_bytes(buf[2]),
+					ridged: HSSeed::from_bytes(buf[3]),
+				},
+				rest,
+			))
+		}
+
+		pub fn perlin(&self) -> HSSeed {
+			self.perlin
+		}
+		pub fn worley(&self) -> HSSeed {
+			self.worley
+		}
+		pub fn billow(&self) -> HSSeed {
+			self.billow
+		}
+		pub fn ridged(&self) -> HSSeed {
+			self.ridged
+		}
+	}
+
+	impl Default for TerrainSeeds {
+		fn default() -> Self {
+			let [perlin, worley, billow, ridged] = HSSeed::many_best_effort();
+			Self {
+				base: random(),
+				perlin,
+				worley,
+				billow,
+				ridged,
+			}
+		}
+	}
+
+	/// Combined heights and strength seed for [ChooseAndSmooth](terrain::noise::ChooseAndSmooth)
+	#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+	#[repr(C)]
+	pub struct HSSeed {
+		heights: u32,
+		strength: u32,
+	}
+
+	impl HSSeed {
+		/// Changing the size of `HSSeed` will break compatibility with older seeds.
+		const _ASSERT_SIZE_8: [u8; 8] = [0; std::mem::size_of::<Self>()];
+
+		pub fn try_not_clashing_with(others: &[u32], attempts: usize) -> Option<Self> {
+			let mut s = random();
+			for _ in 0..attempts {
+				if !others.contains(&s) {
+					return Some(Self {
+						heights: random(),
+						strength: s,
+					});
+				} else {
+					trace!("{} clashes with [{}]", URL_SAFE.encode(s.to_le_bytes()), {
+						let mut encoded = String::with_capacity((others.len() * 4).div_ceil(3));
+						for other in others {
+							URL_SAFE.encode_string(other.to_le_bytes(), &mut encoded);
+						}
+						encoded
+					});
+					s = random();
+				}
+			}
+			None
+		}
+
+		pub fn best_effort(others: &[u32]) -> Self {
+			const ATTEMPTS: usize = 1024;
+			Self::try_not_clashing_with(others, ATTEMPTS).unwrap_or_else(|| {
+				let s = random();
+				if others.contains(&s) {
+					let mut encoded = String::with_capacity((others.len() * 4).div_ceil(3));
+					for other in others {
+						URL_SAFE.encode_string(other.to_le_bytes(), &mut encoded);
+					}
+					error!(
+						"Couldn't find a non-clashing strength seed in {ATTEMPTS} attempts. \
+					Using {} despite it clashing with [{encoded}].",
+						URL_SAFE.encode(s.to_le_bytes())
+					);
+				} else {
+					trace!(
+						"One last attempt found {}",
+						URL_SAFE.encode(s.to_le_bytes())
+					);
+				}
+				Self {
+					heights: random(),
+					strength: s,
+				}
+			})
+		}
+
+		pub fn many_best_effort<const LEN: usize>() -> [Self; LEN] {
+			let mut ret = [Self {
+				heights: 0,
+				strength: 0,
+			}; LEN];
+			let mut buf = [0; LEN];
+			for i in 0..LEN {
+				let new = Self::best_effort(&buf[0..i]);
+				ret[i] = new;
+				buf[i] = new.strength;
+			}
+			ret
+		}
+
+		pub fn bytes(self) -> [u8; std::mem::size_of::<Self>()] {
+			unsafe {
+				// All std ways of doing this are either unstable or work with slices instead of arrays
+				std::mem::transmute([self.heights.to_le_bytes(), self.strength.to_le_bytes()])
+			}
+		}
+
+		pub fn from_bytes(bytes: [u8; std::mem::size_of::<Self>()]) -> Self {
+			let [heights, strength] = unsafe {
+				// All std ways of doing this are either unstable or work with slices instead of arrays
+				std::mem::transmute(bytes)
+			};
+			Self {
+				heights: u32::from_le_bytes(heights),
+				strength: u32::from_le_bytes(strength),
+			}
+		}
+
+		pub fn heights(&self) -> u32 {
+			self.heights
+		}
+		pub fn strength(&self) -> u32 {
+			self.strength
+		}
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use crate::planet::seeds::PlanetSeed;
+
+		#[test]
+		fn seed_base64_round_trip() {
+			let seed = PlanetSeed::default();
+			let encoded = seed.base64();
+			let decoded = PlanetSeed::from_base64(encoded);
+			assert_eq!(Ok(seed), decoded);
+		}
+	}
+}

--- a/rs/src/planet.rs
+++ b/rs/src/planet.rs
@@ -3,7 +3,9 @@ use bevy::prelude::*;
 use bevy_rapier3d::na::{Vector2, Vector3};
 use serde::{Deserialize, Serialize};
 use std::ops::{Add, Sub};
+use crate::planet::chunks::{ChunkIndex, LoadedChunks};
 use crate::planet::frame::PlanetFramePlugin;
+use crate::util::Diff;
 
 pub mod chunks;
 pub mod day_night;
@@ -15,6 +17,7 @@ pub fn plugin(app: &mut App) -> &mut App {
 	app.add_plugins((terrain::plugin.plugfn(), day_night::plugin.plugfn(), PlanetFramePlugin))
 		.init_resource::<DayNightCycle>()
 		.register_type::<DayNightCycle>()
+		.init_resource::<LoadedChunks>()
 }
 
 #[derive(Default, Debug, Copy, Clone, Deref, DerefMut, PartialEq, Serialize, Deserialize)]
@@ -24,10 +27,13 @@ impl PlanetVec3 {
 	pub fn new(x: f64, y: f64, z: f64) -> Self {
 		Self(Vector3::new(x, y, z))
 	}
+}
 
-	pub fn relative_to(self, other: Self) -> Vec3 {
-		let diff = self - other;
-		diff.into()
+impl Diff for PlanetVec3 {
+	type Delta = Vec3;
+	
+	fn delta_from(&self, rhs: &Self) -> Self::Delta {
+		(*self - *rhs).into()
 	}
 }
 
@@ -91,9 +97,16 @@ impl PlanetVec2 {
 		Self(Vector2::new(x, y))
 	}
 
-	pub fn relative_to(self, other: Self) -> Vec2 {
-		let diff = self - other;
-		diff.into()
+	pub fn closest_chunk(self) -> ChunkIndex {
+		self.into()
+	}
+}
+
+impl Diff for PlanetVec2 {
+	type Delta = Vec2;
+	
+	fn delta_from(&self, rhs: &Self) -> Self::Delta {
+		(*self - *rhs).into()
 	}
 }
 

--- a/rs/src/planet.rs
+++ b/rs/src/planet.rs
@@ -1,12 +1,18 @@
-use std::any::Any;
-use crate::{planet::day_night::DayNightCycle, util::IntoFnPlugin};
+use crate::{
+	planet::{
+		chunks::{ChunkIndex, LoadedChunks},
+		day_night::DayNightCycle,
+		frame::PlanetFramePlugin,
+	},
+	util::{Diff, IntoFnPlugin},
+};
 use bevy::prelude::*;
 use bevy_rapier3d::na::{Vector2, Vector3};
 use serde::{Deserialize, Serialize};
-use std::ops::{Add, Deref, DerefMut, Sub};
-use crate::planet::chunks::{ChunkIndex, LoadedChunks};
-use crate::planet::frame::PlanetFramePlugin;
-use crate::util::Diff;
+use std::{
+	any::Any,
+	ops::{Add, Deref, DerefMut, Sub},
+};
 
 pub mod chunks;
 pub mod day_night;
@@ -15,13 +21,17 @@ pub mod sky;
 pub mod terrain;
 
 pub fn plugin(app: &mut App) -> &mut App {
-	app.add_plugins((terrain::plugin.plugfn(), day_night::plugin.plugfn(), PlanetFramePlugin))
-		.init_resource::<DayNightCycle>()
-		.register_type::<DayNightCycle>()
-		.init_resource::<LoadedChunks>()
+	app.add_plugins((
+		terrain::plugin.plugfn(),
+		day_night::plugin.plugfn(),
+		PlanetFramePlugin,
+	))
+	.init_resource::<DayNightCycle>()
+	.register_type::<DayNightCycle>()
+	.init_resource::<LoadedChunks>()
 }
 
-#[derive(Default, Debug, Copy, Clone, PartialEq, Serialize, Deserialize, Reflect,)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Serialize, Deserialize, Reflect)]
 #[repr(C)]
 pub struct PlanetVec3 {
 	x: f64,
@@ -54,7 +64,7 @@ impl From<Vec3> for PlanetVec3 {
 
 impl Deref for PlanetVec3 {
 	type Target = Vector3<f64>;
-	
+
 	fn deref(&self) -> &Self::Target {
 		// SAFETY: Vector3 is `#[repr(C)]` and transmutes to `XY<T> { x: T, y: T, z: T } in `nalgebra::coordinates`
 		unsafe { &*(self as *const Self as *const _) }
@@ -70,7 +80,7 @@ impl DerefMut for PlanetVec3 {
 
 impl Diff for PlanetVec3 {
 	type Delta = Vec3;
-	
+
 	fn delta_from(&self, rhs: &Self) -> Self::Delta {
 		(*self - *rhs).into()
 	}
@@ -120,9 +130,7 @@ impl Sub<Vec3> for PlanetVec3 {
 	}
 }
 
-#[derive(
-	Component, Default, Debug, Copy, Clone, PartialEq, Serialize, Deserialize, Reflect,
-)]
+#[derive(Component, Default, Debug, Copy, Clone, PartialEq, Serialize, Deserialize, Reflect)]
 #[repr(C)]
 pub struct PlanetVec2 {
 	x: f64,
@@ -131,7 +139,7 @@ pub struct PlanetVec2 {
 
 impl Deref for PlanetVec2 {
 	type Target = Vector2<f64>;
-	
+
 	fn deref(&self) -> &Self::Target {
 		// SAFETY: Vector2 is `#[repr(C)]` and transmutes to `XY<T> { x: T, y: T } in `nalgebra::coordinates`
 		unsafe { &*(self as *const Self as *const _) }
@@ -167,7 +175,7 @@ impl PlanetVec2 {
 
 impl Diff for PlanetVec2 {
 	type Delta = Vec2;
-	
+
 	fn delta_from(&self, rhs: &Self) -> Self::Delta {
 		(*self - *rhs).into()
 	}
@@ -175,7 +183,10 @@ impl Diff for PlanetVec2 {
 
 impl From<Vec2> for PlanetVec2 {
 	fn from(value: Vec2) -> Self {
-		Self { x: value.x as f64, y: value.y as f64 }
+		Self {
+			x: value.x as f64,
+			y: value.y as f64,
+		}
 	}
 }
 

--- a/rs/src/planet/chunks.rs
+++ b/rs/src/planet/chunks.rs
@@ -1,15 +1,16 @@
 use super::terrain::Ground;
 use crate::planet::PlanetVec2;
-use bevy::{prelude::*, utils::HashMap};
+use bevy::prelude::*;
 use bevy_rapier3d::na::Vector3;
+use bimap::BiMap;
 
 pub const CHUNK_ROWS: usize = 128;
 pub const CHUNK_COLS: usize = 128;
-pub const TERRAIN_CELL_SIZE: Vec2 = Vec2::new(16.0, 16.0);
+pub const TERRAIN_CELL_SIZE: f32 = 16.0;
 pub const CHUNK_SCALE: Vector3<f32> = Vector3::new(
-	CHUNK_COLS as f32 * TERRAIN_CELL_SIZE.x,
+	CHUNK_COLS as f32 * TERRAIN_CELL_SIZE,
 	1024.0,
-	CHUNK_ROWS as f32 * TERRAIN_CELL_SIZE.y,
+	CHUNK_ROWS as f32 * TERRAIN_CELL_SIZE,
 );
 
 #[derive(Bundle, Debug)]
@@ -32,13 +33,19 @@ impl ChunkIndex {
 	pub fn new(x: i32, y: i32) -> Self {
 		Self { x, y }
 	}
+	pub fn center(self) -> ChunkCenter {
+		self.into()
+	}
+	pub fn manhattan_dist(self, other: Self) -> u32 {
+		(other.x - self.x).unsigned_abs() + (other.y - self.y).unsigned_abs()
+	}
 }
 
 impl From<ChunkIndex> for ChunkCenter {
 	fn from(value: ChunkIndex) -> Self {
 		Self(PlanetVec2::new(
-			value.x as f64 * (CHUNK_COLS as f64 * TERRAIN_CELL_SIZE.x as f64),
-			value.y as f64 * (CHUNK_ROWS as f64 * TERRAIN_CELL_SIZE.y as f64),
+			value.x as f64 * (CHUNK_COLS as f64 * TERRAIN_CELL_SIZE as f64),
+			value.y as f64 * (CHUNK_ROWS as f64 * TERRAIN_CELL_SIZE as f64),
 		))
 	}
 }
@@ -46,11 +53,23 @@ impl From<ChunkIndex> for ChunkCenter {
 impl From<PlanetVec2> for ChunkIndex {
 	fn from(value: PlanetVec2) -> Self {
 		Self::new(
-			((value.x / (CHUNK_COLS as f64 * TERRAIN_CELL_SIZE.x as f64)) + 0.5) as i32,
-			((value.y / (CHUNK_ROWS as f64 * TERRAIN_CELL_SIZE.y as f64)) + 0.5) as i32,
+			((value.x / (CHUNK_COLS as f64 * TERRAIN_CELL_SIZE as f64)) + 0.5) as i32,
+			((value.y / (CHUNK_ROWS as f64 * TERRAIN_CELL_SIZE as f64)) + 0.5) as i32,
 		)
 	}
 }
 
 #[derive(Resource, Default, Debug, Deref, DerefMut)]
-pub struct LoadedChunks(HashMap<ChunkIndex, Entity>);
+pub struct LoadedChunks(BiMap<ChunkIndex, Entity>);
+
+impl LoadedChunks {
+	pub fn closest_to(&self, point: PlanetVec2) -> Option<(ChunkIndex, Entity)> {
+		let maybe_loaded = ChunkIndex::from(point);
+		if let Some(id) = self.get_by_left(&maybe_loaded) {
+			return Some((maybe_loaded, *id))
+		}
+		self.iter()
+			.map(|(index, id)| (*index, *id))
+			.min_by_key(|(index, id)| index.manhattan_dist(maybe_loaded))
+	}
+}

--- a/rs/src/planet/chunks.rs
+++ b/rs/src/planet/chunks.rs
@@ -4,8 +4,8 @@ use bevy::prelude::*;
 use bevy_rapier3d::na::Vector3;
 use bimap::BiMap;
 
-pub const CHUNK_ROWS: usize = 128;
-pub const CHUNK_COLS: usize = 128;
+pub const CHUNK_ROWS: usize = 64;
+pub const CHUNK_COLS: usize = 64;
 pub const TERRAIN_CELL_SIZE: f32 = 16.0;
 pub const CHUNK_SCALE: Vector3<f32> = Vector3::new(
 	CHUNK_COLS as f32 * TERRAIN_CELL_SIZE,

--- a/rs/src/planet/chunks.rs
+++ b/rs/src/planet/chunks.rs
@@ -53,8 +53,8 @@ impl From<ChunkIndex> for ChunkCenter {
 impl From<PlanetVec2> for ChunkIndex {
 	fn from(value: PlanetVec2) -> Self {
 		Self::new(
-			((value.x / (CHUNK_COLS as f64 * TERRAIN_CELL_SIZE as f64)) + 0.5) as i32,
-			((value.y / (CHUNK_ROWS as f64 * TERRAIN_CELL_SIZE as f64)) + 0.5) as i32,
+			(value.x / (CHUNK_COLS as f64 * TERRAIN_CELL_SIZE as f64)).round() as i32,
+			(value.y / (CHUNK_ROWS as f64 * TERRAIN_CELL_SIZE as f64)).round() as i32,
 		)
 	}
 }

--- a/rs/src/planet/chunks.rs
+++ b/rs/src/planet/chunks.rs
@@ -66,7 +66,7 @@ impl LoadedChunks {
 	pub fn closest_to(&self, point: PlanetVec2) -> Option<(ChunkIndex, Entity)> {
 		let maybe_loaded = ChunkIndex::from(point);
 		if let Some(id) = self.get_by_left(&maybe_loaded) {
-			return Some((maybe_loaded, *id))
+			return Some((maybe_loaded, *id));
 		}
 		self.iter()
 			.map(|(index, id)| (*index, *id))

--- a/rs/src/planet/frame.rs
+++ b/rs/src/planet/frame.rs
@@ -6,12 +6,12 @@ use bevy_rapier3d::prelude::TransformInterpolation;
 use enum_components::ERef;
 use particles::{PreviousGlobalTransform, PreviousTransform};
 use serde::{Deserialize, Serialize};
-use crate::planet::chunks::TERRAIN_CELL_SIZE;
+use crate::planet::chunks::{ChunkIndex, TERRAIN_CELL_SIZE};
 use crate::planet::PlanetVec2;
 use crate::player::player_entity::Root;
 use crate::util::Prev;
 
-pub const MIN_FRAME_WIDTH: f32 = 128.0 * TERRAIN_CELL_SIZE.x;
+pub const MIN_FRAME_WIDTH: f32 = 128.0 * TERRAIN_CELL_SIZE;
 
 pub struct PlanetFramePlugin;
 
@@ -27,6 +27,15 @@ impl Plugin for PlanetFramePlugin {
 pub struct Frame {
 	pub center: PlanetVec2,
 	pub trigger_bounds: f32,
+}
+
+impl Frame {
+	pub fn planet_coords_of(&self, point: Vec2) -> PlanetVec2 {
+		self.center + point
+	}
+	pub fn closest_chunk(&self, point: Vec2) -> ChunkIndex {
+		self.planet_coords_of(point).into()
+	}
 }
 
 impl Default for Frame {

--- a/rs/src/planet/frame.rs
+++ b/rs/src/planet/frame.rs
@@ -1,0 +1,148 @@
+use bevy::prelude::*;
+use bevy_rapier3d::dynamics::RapierRigidBodyHandle;
+use bevy_rapier3d::na::Vector;
+use bevy_rapier3d::plugin::RapierContext;
+use bevy_rapier3d::prelude::TransformInterpolation;
+use enum_components::ERef;
+use particles::{PreviousGlobalTransform, PreviousTransform};
+use serde::{Deserialize, Serialize};
+use crate::planet::chunks::TERRAIN_CELL_SIZE;
+use crate::planet::PlanetVec2;
+use crate::player::player_entity::Root;
+use crate::util::Prev;
+
+pub const MIN_FRAME_WIDTH: f32 = 128.0 * TERRAIN_CELL_SIZE.x;
+
+pub struct PlanetFramePlugin;
+
+impl Plugin for PlanetFramePlugin {
+	fn build(&self, app: &mut App) {
+		app.add_systems(First, (shift_frame, reframe_all_entities).chain())
+			.insert_resource(Frame::default())
+			.insert_resource(Prev::<Frame>::default());
+	}
+}
+
+#[derive(Resource, Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Frame {
+	pub center: PlanetVec2,
+	pub trigger_bounds: f32,
+}
+
+impl Default for Frame {
+	fn default() -> Self {
+		Self {
+			center: default(),
+			trigger_bounds: MIN_FRAME_WIDTH,
+		}
+	}
+}
+
+pub fn reframe_all_entities(
+	mut ctx: ResMut<RapierContext>,
+	mut q: Query<(&mut Transform, &mut GlobalTransform, Has<Parent>)>,
+	bodies: Query<&RapierRigidBodyHandle>,
+	mut interpolations: Query<&mut TransformInterpolation, Without<Parent>>,
+	mut prev_xforms: Query<&mut Prev<Transform>, Without<Parent>>,
+	mut prev_globals: Query<&mut Prev<GlobalTransform>>,
+	mut prev_particles: Query<(&mut PreviousTransform, &mut PreviousGlobalTransform)>,
+	frame: Res<Frame>,
+	prev_frame: Res<Prev<Frame>>,
+) {
+	if !frame.is_changed() || frame.is_added() || frame.center == prev_frame.center {
+		return
+	}
+	info!("{frame:?}");
+	let diff = Vec2::from(frame.center - prev_frame.center);
+	let offset = Vec3::new(-diff.x, -diff.y, 0.0);
+	for (mut xform, mut global, has_parent) in &mut q {
+		if !has_parent {
+			xform.translation += offset;
+		}
+		let global_xform = global.compute_transform();
+		*global = GlobalTransform::from(Transform { translation: global_xform.translation, ..global_xform });
+	}
+	for mut prev_xform in &mut prev_xforms {
+		prev_xform.translation += offset;
+	}
+	for mut prev_global in &mut prev_globals {
+		let mut computed = prev_global.compute_transform();
+		computed.translation += offset;
+		**prev_global = GlobalTransform::from(computed);
+	}
+	for (mut prev_xform, mut prev_global) in &mut prev_particles {
+		prev_xform.translation += offset;
+		let mut computed = prev_global.compute_transform();
+		computed.translation += offset;
+		**prev_global = GlobalTransform::from(computed);
+	}
+	
+	// Rapier transforms
+	let offset = Vector::from(offset);
+	for body in &bodies {
+		if let Some(mut body) = ctx.bodies.get_mut(body.0) {
+			let pos = body.translation();
+			body.set_translation(*pos + offset, false);
+		}
+	}
+	for mut interp in &mut interpolations {
+		interp.start.as_mut().map(|start| start.translation.vector += offset);
+		interp.end.as_mut().map(|end| end.translation.vector += offset);
+	}
+}
+
+pub fn shift_frame(
+	player_q: Query<&GlobalTransform, ERef<Root>>,
+	mut frame: ResMut<Frame>,
+	mut prev_frame: ResMut<Prev<Frame>>,
+) {
+	if **prev_frame != *frame {
+		**prev_frame = *frame;
+	}
+	let mut min = Vec2::NAN;
+	let mut max = Vec2::NAN;
+	for global in &player_q {
+		let global = global.translation();
+		min.x = f32::min(min.x, global.x);
+		max.x = f32::max(max.x, global.x);
+		min.y = f32::min(min.y, global.y);
+		max.y = f32::max(max.y, global.y);
+	}
+	
+	// Prepare to handle players being too far apart.
+	// Should probably have separate frames for different players if possible, but
+	// this is far easier to implement.
+	const GROW: f32 = 1.512;
+	// Should be less than `GROW * 0.5` in order to prevent oscillation when
+	// `*_width` is multiplied by `GROW`
+	const SHRINK_TRIGGER: f32 = 0.5;
+	let mut grew = false;
+	let x_width = max.x - min.x;
+	if x_width >= frame.trigger_bounds {
+		frame.trigger_bounds = x_width * GROW;
+		grew = true;
+	}
+	let y_width = max.y - min.y;
+	if y_width >= frame.trigger_bounds {
+		frame.trigger_bounds = f32::max(frame.trigger_bounds, y_width * GROW);
+		grew = true;
+	}
+	
+	// Automatically shrink to recover precision
+	if !grew && x_width < frame.trigger_bounds * SHRINK_TRIGGER && y_width < frame.trigger_bounds * SHRINK_TRIGGER {
+		frame.trigger_bounds = f32::max(f32::max(x_width * GROW, y_width * GROW), MIN_FRAME_WIDTH);
+	}
+	
+	let midpoint = Vec2::new(
+		(x_width * 0.5) + min.x,
+		(y_width * 0.5) + min.y,
+	);
+	
+	// Actually move the frame if needed
+	if midpoint.x.abs() >= frame.trigger_bounds {
+		frame.center.x += midpoint.x.signum() as f64 * frame.trigger_bounds as f64;
+	}
+	if midpoint.y.abs() >= frame.trigger_bounds {
+		frame.center.y += midpoint.y.signum() as f64 * frame.trigger_bounds as f64;
+	}
+}

--- a/rs/src/planet/terrain.rs
+++ b/rs/src/planet/terrain.rs
@@ -24,6 +24,7 @@ use bevy_rapier3d::{parry::shape::SharedShape, prelude::*};
 use rapier3d::{geometry::HeightField, na::DMatrix};
 use std::{f32::consts::*, sync::Arc};
 use web_time::{Duration, Instant};
+use crate::planet::chunks::LoadedChunks;
 
 pub mod noise;
 
@@ -348,6 +349,7 @@ pub fn spawn_loaded_chunks(
 	mut cmds: Commands,
 	mut tasks: ResMut<ChunkLoadingTasks>,
 	mat: Res<TerrainMaterial>,
+	mut loaded_chunks: ResMut<LoadedChunks>,
 ) {
 	tasks.retain_mut(|(index, task)| {
 		// TODO: Relative to current frame
@@ -355,12 +357,12 @@ pub fn spawn_loaded_chunks(
 		let translation = Vec2::from(center.0);
 		if let Some((heights, mesh)) = task.check() {
 			let heights = Arc::new(heights);
-			cmds.spawn((
+			let id = cmds.spawn((
 				TerrainObject {
 					pbr: PbrBundle {
 						mesh,
 						transform: Transform {
-							translation: Vec3::new(translation.x, translation.y, -768.0),
+							translation: Vec3::new(translation.x, translation.y, 0.0),
 							rotation: Quat::from_rotation_x(FRAC_PI_2),
 							..default()
 						},
@@ -374,7 +376,10 @@ pub fn spawn_loaded_chunks(
 				center,
 				Ground { heights },
 				NoAutomaticBatching,
-			));
+			)).id();
+			
+			loaded_chunks.insert(*index, id);
+			
 			// remove from tasks vec
 			false
 		} else {

--- a/rs/src/planet/terrain.rs
+++ b/rs/src/planet/terrain.rs
@@ -9,7 +9,10 @@ use crate::{
 		},
 		frame::Frame,
 		seeds::PlanetSeed,
-		terrain::noise::{ChooseAndSmooth, Source, SyncWorley},
+		terrain::{
+			noise::{ChooseAndSmooth, Source, SyncWorley},
+			seeds::TerrainSeeds,
+		},
 		PlanetVec2,
 	},
 	player::player_entity::Root,
@@ -59,93 +62,10 @@ pub fn setup(
 	let material = assets.load("shaders/terrain.mat.ron");
 
 	cmds.insert_resource(TerrainMaterial(material.clone()));
-	let seeds = PlanetSeed::default();
-	info!(name: "seed", seed = %seeds);
-	let seeds = seeds.tera;
+	let seed = rand::random::<PlanetSeed>();
+	info!(name: "seed", seed = %seed);
 
-	// Add is not Clone, so we'll use a closure to get multiple copies
-	let base = || {
-		Add::new(
-			ScaleBias::new(
-				HybridMulti::<Value>::default()
-					.set_frequency(0.00032)
-					.set_persistence(0.5),
-			)
-			.set_scale(2.0),
-			Fbm::<Perlin>::default()
-				.set_frequency(0.00128)
-				.set_octaves(2)
-				.set_persistence(0.45)
-				.set_seed(seeds.base),
-		)
-	};
-
-	let strength_noise = Fbm::<Perlin>::default()
-		.set_frequency(0.00128)
-		.set_octaves(2)
-		.set_seed(seeds.perlin().strength());
-
-	let perlin = Source::new(
-		Add::new(
-			ScaleBias::new(
-				Fbm::<Perlin>::default()
-					.set_frequency(0.0256)
-					.set_persistence(0.45)
-					.set_seed(seeds.perlin().heights()),
-			)
-			.set_scale(0.05),
-			base(),
-		),
-		strength_noise.clone(),
-		// Constant::new(-1.0),
-	);
-
-	let worley = Source::new(
-		Add::new(
-			ScaleBias::new(
-				SyncWorley::default()
-					.set_frequency(0.05)
-					.set_seed(seeds.worley().heights()),
-			)
-			.set_scale(0.1),
-			base(),
-		),
-		strength_noise.clone().set_seed(seeds.worley().strength()),
-		// Constant::new(-1.0),
-	);
-
-	let billow = Source::new(
-		Add::new(
-			ScaleBias::new(
-				Billow::<Perlin>::default()
-					.set_frequency(0.02)
-					.set_octaves(2)
-					.set_seed(seeds.billow().heights()),
-			)
-			.set_scale(0.04),
-			base(),
-		),
-		strength_noise.clone().set_seed(seeds.billow().strength()),
-		// Constant::new(-1.0),
-	);
-
-	let ridged = Source::new(
-		Add::new(
-			ScaleBias::new(
-				RidgedMulti::<Perlin>::default()
-					.set_frequency(0.02)
-					.set_seed(seeds.ridged().heights()),
-			)
-			.set_scale(0.07),
-			base(),
-		),
-		strength_noise.clone().set_seed(seeds.ridged().strength()),
-		// Constant::new(-1.0),
-	);
-
-	let noise = ChooseAndSmooth::new([perlin, worley, billow, ridged]);
-
-	let noise = PlanetHeightSource::new(noise);
+	let noise = PlanetHeightSource::generate((&seed).into());
 
 	// Spawn center first
 	generate_chunk(
@@ -156,6 +76,7 @@ pub fn setup(
 		&mut task_offloader,
 	);
 
+	cmds.insert_resource(seed);
 	cmds.insert_resource(noise);
 
 	let mesh = Mesh::from(shape::Cube { size: 64.0 })
@@ -323,6 +244,98 @@ impl PlanetHeightSource {
 			noise: noise.into(),
 		}
 	}
+
+	pub fn generate(seeds: TerrainSeeds) -> Self {
+		let base = bytemuck::cast::<_, [u32; 2]>(seeds.base());
+		let perlin = Perlin::default().set_seed(base[0]);
+		let sources = vec![perlin, perlin.set_seed(base[1])];
+
+		// unfortunately this generates sources that are immediately discarded, but `sources` isn't pub
+		let mut base = Fbm::<Perlin>::default();
+		base.octaves = 2;
+		base.frequency = 0.00128;
+		base.persistence = 0.45;
+		let base = base.set_sources(sources);
+
+		// Add and ScaleBias are not Clone, so we'll use a closure to get multiple copies
+		let base = || {
+			Add::new(
+				ScaleBias::new(
+					HybridMulti::<Value>::default()
+						.set_frequency(0.00032)
+						.set_persistence(0.5),
+				)
+				.set_scale(2.0),
+				base.clone(),
+			)
+		};
+
+		let strength_noise = Fbm::<Perlin>::default()
+			.set_frequency(0.00128)
+			.set_octaves(2)
+			.set_seed(seeds.perlin().strength());
+
+		let perlin = Source::new(
+			Add::new(
+				ScaleBias::new(
+					Fbm::<Perlin>::default()
+						.set_frequency(0.0256)
+						.set_persistence(0.45)
+						.set_seed(seeds.perlin().heights()),
+				)
+				.set_scale(0.05),
+				base(),
+			),
+			strength_noise.clone(),
+			// Constant::new(-1.0),
+		);
+
+		let worley = Source::new(
+			Add::new(
+				ScaleBias::new(
+					SyncWorley::default()
+						.set_frequency(0.05)
+						.set_seed(seeds.worley().heights()),
+				)
+				.set_scale(0.1),
+				base(),
+			),
+			strength_noise.clone().set_seed(seeds.worley().strength()),
+			// Constant::new(-1.0),
+		);
+
+		let billow = Source::new(
+			Add::new(
+				ScaleBias::new(
+					Billow::<Perlin>::default()
+						.set_frequency(0.02)
+						.set_octaves(2)
+						.set_seed(seeds.billow().heights()),
+				)
+				.set_scale(0.04),
+				base(),
+			),
+			strength_noise.clone().set_seed(seeds.billow().strength()),
+			// Constant::new(-1.0),
+		);
+
+		let ridged = Source::new(
+			Add::new(
+				ScaleBias::new(
+					RidgedMulti::<Perlin>::default()
+						.set_frequency(0.02)
+						.set_seed(seeds.ridged().heights()),
+				)
+				.set_scale(0.07),
+				base(),
+			),
+			strength_noise.clone().set_seed(seeds.ridged().strength()),
+			// Constant::new(-1.0),
+		);
+
+		let noise = ChooseAndSmooth::new([perlin, worley, billow, ridged]);
+		Self::new(noise)
+	}
 }
 
 #[derive(Resource, Default, Deref, DerefMut)]
@@ -459,3 +472,170 @@ pub fn unload_distant_chunks(
 
 #[derive(Resource, Deref, DerefMut, Debug, Reflect)]
 pub struct UnloadDistance(f32);
+
+mod seeds {
+	use crate::planet::{seeds::PlanetSeed, terrain};
+	use bevy::utils::RandomState;
+	use std::hash::{BuildHasher, Hasher};
+
+	#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+	#[repr(C)]
+	pub struct TerrainSeeds {
+		base: u64,
+		perlin: HSSeed,
+		worley: HSSeed,
+		billow: HSSeed,
+		ridged: HSSeed,
+	}
+
+	impl From<&PlanetSeed> for TerrainSeeds {
+		fn from(value: &PlanetSeed) -> Self {
+			let value = value.hash();
+
+			// Randomly generated during development.
+			// WARNING: Changing these will break compatibility with older seeds.
+			let mut hasher = RandomState::with_seeds(
+				14290938944643142730,
+				324773583170826462,
+				5391126888610969733,
+				8770814408611468823,
+			)
+			.build_hasher();
+
+			hasher.write(value);
+			let base = hasher.finish();
+			hasher.write(value);
+			let perlin = bytemuck::cast::<_, [u32; 2]>(hasher.finish());
+			hasher.write(value);
+			let mut worley = bytemuck::cast::<_, [u32; 2]>(hasher.finish());
+			for _ in 0..1024 {
+				// Best effort at avoiding strength collisions.
+				if perlin[1] == worley[1] {
+					hasher.write(value);
+					worley = bytemuck::cast(hasher.finish());
+				} else {
+					break;
+				}
+			}
+
+			hasher.write(value);
+			let mut billow = bytemuck::cast::<_, [u32; 2]>(hasher.finish());
+			for _ in 0..1024 {
+				// Best effort at avoiding strength collisions.
+				if [perlin[1], worley[1]].contains(&billow[1]) {
+					hasher.write(value);
+					billow = bytemuck::cast(hasher.finish());
+				} else {
+					break;
+				}
+			}
+
+			hasher.write(value);
+			let mut ridged = bytemuck::cast::<_, [u32; 2]>(hasher.finish());
+			for _ in 0..1024 {
+				// Best effort at avoiding strength collisions.
+				if [perlin[1], worley[1], billow[1]].contains(&ridged[1]) {
+					hasher.write(value);
+					ridged = bytemuck::cast(hasher.finish());
+				} else {
+					break;
+				}
+			}
+
+			Self {
+				base,
+				perlin: HSSeed::new(perlin[0], perlin[1]),
+				worley: HSSeed::new(worley[0], worley[1]),
+				billow: HSSeed::new(billow[0], billow[1]),
+				ridged: HSSeed::new(ridged[0], ridged[1]),
+			}
+		}
+	}
+
+	impl TerrainSeeds {
+		pub fn base(&self) -> u64 {
+			self.base
+		}
+
+		pub fn perlin(&self) -> HSSeed {
+			self.perlin
+		}
+		pub fn worley(&self) -> HSSeed {
+			self.worley
+		}
+		pub fn billow(&self) -> HSSeed {
+			self.billow
+		}
+		pub fn ridged(&self) -> HSSeed {
+			self.ridged
+		}
+	}
+
+	/// Combined heights and strength seed for [ChooseAndSmooth](terrain::noise::ChooseAndSmooth)
+	#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+	#[repr(C)]
+	pub struct HSSeed {
+		heights: u32,
+		strength: u32,
+	}
+
+	impl HSSeed {
+		fn new(heights: u32, strength: u32) -> Self {
+			Self { heights, strength }
+		}
+
+		pub fn heights(&self) -> u32 {
+			self.heights
+		}
+		pub fn strength(&self) -> u32 {
+			self.strength
+		}
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use crate::planet::{
+			seeds::PlanetSeed,
+			terrain::seeds::{HSSeed, TerrainSeeds},
+		};
+
+		#[test]
+		fn seed_equivalence() {
+			let seed = rand::random::<PlanetSeed>();
+			let a = TerrainSeeds::from(&seed);
+			let b = TerrainSeeds::from(&seed);
+			assert_eq!(a, b);
+		}
+
+		#[test]
+		fn version_equivalence() {
+			// Note: If sources are added or removed, the sources from the previous version should remain equivalent,
+			// but it is fine to add the values for the new sources or remove old ones here.
+			let seed = PlanetSeed::from(
+				"This is a PlanetSeed for testing TerrainSeed equivalence across versions.",
+			);
+			assert_eq!(
+				TerrainSeeds::from(&seed),
+				TerrainSeeds {
+					base: 7920230168977959780,
+					perlin: HSSeed {
+						heights: 2685576922,
+						strength: 1151182273
+					},
+					worley: HSSeed {
+						heights: 895711232,
+						strength: 484265962
+					},
+					billow: HSSeed {
+						heights: 3037546005,
+						strength: 57840775
+					},
+					ridged: HSSeed {
+						heights: 401089611,
+						strength: 2179398915
+					}
+				},
+			);
+		}
+	}
+}

--- a/rs/src/planet/terrain.rs
+++ b/rs/src/planet/terrain.rs
@@ -2,11 +2,16 @@ use crate::{
 	nav::heightmap::FnsThatShouldBePub,
 	offloading::{wasm_yield, Offload, OffloadedTask, TaskHandle, TaskOffloader},
 	planet::{
-		chunks::{ChunkCenter, ChunkIndex, LoadedChunks, CHUNK_COLS, CHUNK_ROWS, CHUNK_SCALE},
+		chunks::{
+			ChunkCenter, ChunkIndex, LoadedChunks, CHUNK_COLS, CHUNK_ROWS, CHUNK_SCALE,
+			TERRAIN_CELL_SIZE,
+		},
+		frame::Frame,
 		terrain::noise::{ChooseAndSmooth, Source, SyncWorley},
 		PlanetVec2,
 	},
-	util::{Factory, Spawnable},
+	player::player_entity::Root,
+	util::{Diff, Factory, Spawnable},
 };
 use ::noise::{
 	Add, Billow, Fbm, HybridMulti, MultiFractal, NoiseFn, Perlin, RidgedMulti, ScaleBias, Seedable,
@@ -19,10 +24,12 @@ use bevy::{
 		batching::NoAutomaticBatching,
 		mesh::{PrimitiveTopology, VertexAttributeValues::Float32x3},
 	},
+	utils::HashMap,
 };
 use bevy_rapier3d::{parry::shape::SharedShape, prelude::*};
+use enum_components::ERef;
 use rapier3d::{geometry::HeightField, na::DMatrix};
-use std::{f32::consts::*, sync::Arc};
+use std::{f32::consts::*, ops::DerefMut, sync::Arc};
 use web_time::{Duration, Instant};
 
 pub mod noise;
@@ -30,10 +37,15 @@ pub mod noise;
 pub type Noise = ChooseAndSmooth<4>;
 
 pub fn plugin(app: &mut App) -> &mut App {
+	// WHY is there no length function on `Vector2`??
+	let diameter = (CHUNK_SCALE.x * CHUNK_SCALE.x + CHUNK_SCALE.y * CHUNK_SCALE.y).sqrt();
+	dbg!(diameter);
 	app.add_systems(Startup, setup)
 		.add_systems(PostStartup, spawn_boxes)
-		.insert_resource(ChunkLoadingTasks::default())
+		.init_resource::<ChunkLoadingTasks>()
+		.insert_resource(UnloadDistance(5.0 * diameter))
 		.add_systems(Update, spawn_loaded_chunks)
+		.add_systems(Last, (load_nearby_chunks, unload_distant_chunks))
 }
 
 pub fn setup(
@@ -51,7 +63,7 @@ pub fn setup(
 
 	cmds.insert_resource(TerrainMaterial(material.clone()));
 
-	// Add is not Clone, so we'll use a closer to get multiple copies
+	// Add is not Clone, so we'll use a closure to get multiple copies
 	let base = || {
 		Add::new(
 			ScaleBias::new(
@@ -119,7 +131,7 @@ pub fn setup(
 
 	let noise = ChooseAndSmooth::new([perlin, worley, billow, ridged]);
 
-	let noise = Arc::new(noise);
+	let noise = PlanetHeightSource::new(noise);
 
 	// Spawn center first
 	generate_chunk(
@@ -129,24 +141,8 @@ pub fn setup(
 		&mut *chunk_loading_tasks,
 		&mut task_offloader,
 	);
-	for i in -3..=3 {
-		for j in -3..=3 {
-			if i == 0 && j == 0 {
-				continue;
-			}
-			generate_chunk(
-				ChunkIndex::new(j, i),
-				assets.clone(),
-				noise.clone(),
-				&mut *chunk_loading_tasks,
-				&mut task_offloader,
-			);
-		}
-	}
 
-	let planet_noise = PlanetHeightSource::new(noise);
-
-	cmds.insert_resource(planet_noise);
+	cmds.insert_resource(noise);
 
 	let mesh = Mesh::from(shape::Cube { size: 64.0 })
 		// All of this makes cube meshes use the same compiled shader as heightmap terrain, preventing freezes
@@ -188,12 +184,12 @@ pub fn spawn_boxes(mut factory: Factory<TerrainObject>) {
 pub fn generate_chunk<'w, 's>(
 	index: ChunkIndex,
 	assets: AssetServer,
-	noise: Arc<Noise>,
+	noise: PlanetHeightSource,
 	chunk_loading_tasks: &mut ChunkLoadingTasks,
 	task_offloader: &mut TaskOffloader<'w, 's>,
 ) {
 	let (columns, rows) = (CHUNK_COLS, CHUNK_ROWS);
-	chunk_loading_tasks.push((
+	chunk_loading_tasks.insert(
 		index,
 		task_offloader.start(async move {
 			let mut last_await = Instant::now();
@@ -240,7 +236,7 @@ pub fn generate_chunk<'w, 's>(
 			let mesh = assets.add(mesh);
 			(heights, mesh)
 		}),
-	));
+	);
 }
 
 /// Share mesh, material, and collider amongst multiple `TerrainObjects`
@@ -301,8 +297,9 @@ pub struct Ground {
 	pub heights: Arc<HeightField>,
 }
 
-#[derive(Resource)]
+#[derive(Resource, Deref, Clone)]
 pub struct PlanetHeightSource {
+	#[deref]
 	pub noise: Arc<Noise>,
 }
 
@@ -312,34 +309,10 @@ impl PlanetHeightSource {
 			noise: noise.into(),
 		}
 	}
-	pub fn local(&self, center: PlanetVec2, size: Vec2) -> LocalHeightSource {
-		LocalHeightSource {
-			center,
-			noise: self.noise.clone(),
-			size,
-		}
-	}
-}
-
-pub struct LocalHeightSource {
-	pub center: PlanetVec2,
-	pub noise: Arc<Noise>,
-	pub size: Vec2,
-}
-
-impl LocalHeightSource {
-	pub fn get(&self, j: usize, i: usize) -> f32 {
-		let local = Vec2 {
-			x: j as f32 - self.size.x * 0.5,
-			y: i as f32 - self.size.y * 0.5,
-		};
-		let point = self.center + local;
-		self.noise.get([point.x, point.y]) as f32
-	}
 }
 
 #[derive(Resource, Default, Deref, DerefMut)]
-pub struct ChunkLoadingTasks(Vec<(ChunkIndex, TaskHandle<(HeightField, Handle<Mesh>)>)>);
+pub struct ChunkLoadingTasks(HashMap<ChunkIndex, TaskHandle<(HeightField, Handle<Mesh>)>>);
 
 #[derive(Resource, Clone, Debug, Deref, DerefMut)]
 pub struct TerrainMaterial(Handle<StandardMaterial>);
@@ -349,11 +322,11 @@ pub fn spawn_loaded_chunks(
 	mut tasks: ResMut<ChunkLoadingTasks>,
 	mat: Res<TerrainMaterial>,
 	mut loaded_chunks: ResMut<LoadedChunks>,
+	frame: Res<Frame>,
 ) {
-	tasks.retain_mut(|(index, task)| {
-		// TODO: Relative to current frame
+	tasks.retain(|index, task| {
 		let center = ChunkCenter::from(*index);
-		let translation = Vec2::from(center.0);
+		let translation = center.delta_from(&frame.center);
 		if let Some((heights, mesh)) = task.check() {
 			let heights = Arc::new(heights);
 			let id = cmds
@@ -389,3 +362,86 @@ pub fn spawn_loaded_chunks(
 		}
 	})
 }
+
+// Pattern ensures that there are always at least 2 chunks beyond the player in any direction.
+#[rustfmt::skip]
+const NEARBY: [(i32, i32); 37] = [
+	                    (-1, -3), (0, -3), ( 1, -3),
+	          (-2, -2), (-1, -2), (0, -2), ( 1, -2), ( 2, -2),
+	(-3, -1), (-2, -1), (-1, -1), (0, -1), ( 1, -1), ( 2, -1), ( 3, -1),
+	(-3,  0), (-2,  0), (-1,  0), (0,  0), ( 1,  0), ( 2,  0), ( 3,  0),
+	(-3,  1), (-2,  1), (-1,  1), (0,  1), ( 1,  1), ( 2,  1), ( 3,  1),
+	          (-2,  2), (-1,  2), (0,  2), ( 1,  2), ( 2,  2),
+	                    (-1,  3), (0,  3), ( 1,  3),
+];
+
+pub fn load_nearby_chunks(
+	players: Query<&GlobalTransform, ERef<Root>>,
+	loaded_chunks: Res<LoadedChunks>,
+	mut tasks: ResMut<ChunkLoadingTasks>,
+	mut task_offloader: TaskOffloader,
+	frame: Res<Frame>,
+	assets: Res<AssetServer>,
+	noise: Res<PlanetHeightSource>,
+) {
+	for player in &players {
+		let player_pos = frame.planet_coords_of(player.translation().xy());
+		for (x, y) in NEARBY {
+			let sample = PlanetVec2::new(
+				(x as f64 * CHUNK_COLS as f64 * TERRAIN_CELL_SIZE as f64) + player_pos.x,
+				(y as f64 * CHUNK_ROWS as f64 * TERRAIN_CELL_SIZE as f64) + player_pos.y,
+			);
+			let chunk = sample.into();
+			if !loaded_chunks.contains_left(&chunk) && !tasks.contains_key(&chunk) {
+				info!("Loading {chunk:?}");
+				generate_chunk(
+					chunk,
+					assets.clone(),
+					noise.clone(),
+					&mut tasks,
+					&mut task_offloader,
+				);
+			}
+		}
+	}
+}
+
+pub fn unload_distant_chunks(
+	mut cmds: Commands,
+	players: Query<&GlobalTransform, ERef<Root>>,
+	chunks: Query<(Entity, &GlobalTransform), With<ChunkCenter>>,
+	dist: Res<UnloadDistance>,
+	mut loaded_chunks: ResMut<LoadedChunks>,
+) {
+	if players.is_empty() {
+		// All players are despawned, don't unload anything until
+		// we can know where they will respawn.
+		return;
+	}
+
+	// WHY is there no length function on `Vector2`??
+	let diameter = (CHUNK_SCALE.x * CHUNK_SCALE.x + CHUNK_SCALE.y * CHUNK_SCALE.y).sqrt();
+
+	// Don't oscillate between loading and unloading
+	// Must allow for player to be in the corner of a chunk
+	// and still not unload cells in `NEARBY`
+	let dist = f32::max(**dist, diameter * 3.6);
+	for (id, global) in &chunks {
+		let global = global.translation().xy();
+		if !players
+			.iter()
+			.find(|player| (global - player.translation().xy()).length() < dist)
+			.is_some()
+		{
+			cmds.entity(id).despawn();
+			if let Some((chunk, _)) = loaded_chunks.remove_by_right(&id) {
+				info!("Unloaded {chunk:?}");
+			} else {
+				warn!("Chunk {id:?} wasn't in the `LoadedChunks` map");
+			}
+		}
+	}
+}
+
+#[derive(Resource, Deref, DerefMut, Debug, Reflect)]
+pub struct UnloadDistance(f32);

--- a/rs/src/player.rs
+++ b/rs/src/player.rs
@@ -339,7 +339,7 @@ pub fn spawn_players(
 				}),
 				KinematicPositionBased,
 				TransformBundle::from_transform(Transform {
-					translation: Vec3::Z * 2048.0,
+					translation: Vec3::Z * 4096.0,
 					..default()
 				}),
 				Velocity::default(),

--- a/rs/src/player.rs
+++ b/rs/src/player.rs
@@ -350,7 +350,7 @@ pub fn spawn_players(
 				}),
 				KinematicPositionBased,
 				TransformBundle::from_transform(Transform {
-					translation: Vec3::Z * 1024.0,
+					translation: Vec3::Z * 2048.0,
 					..default()
 				}),
 				Velocity::default(),

--- a/rs/src/player.rs
+++ b/rs/src/player.rs
@@ -349,7 +349,10 @@ pub fn spawn_players(
 					angvel: Vect::new(0.0, 0.0, PI / crate::DT), // Half a rotation per physics tick
 				}),
 				KinematicPositionBased,
-				TransformBundle::default(),
+				TransformBundle::from_transform(Transform {
+					translation: Vec3::Z * 1024.0,
+					..default()
+				}),
 				Velocity::default(),
 				Friction {
 					coefficient: 0.0,

--- a/rs/src/player/camera.rs
+++ b/rs/src/player/camera.rs
@@ -4,7 +4,9 @@ use super::{
 };
 use crate::{planet::sky::SkyShader, player::PlayerId, settings::Settings, NeverDespawn};
 
-use crate::{anim::ComponentDelta, player::prefs::CamSmoothing, util::LerpSlerp};
+use crate::{
+	anim::ComponentDelta, player::prefs::CamSmoothing, util::LerpSlerp,
+};
 use bevy::{
 	core_pipeline::{
 		bloom::BloomSettings, clear_color::ClearColorConfig, fxaa::Fxaa, tonemapping::Tonemapping,
@@ -133,10 +135,6 @@ pub fn spawn_camera<'w, 's, 'a>(
 				},
 				transform: Transform {
 					rotation: Quat::from_rotation_x(FRAC_PI_2),
-					..default()
-				},
-				camera_3d: Camera3d {
-					clear_color: ClearColorConfig::Custom(Color::rgb(0.024, 0.0, 0.036)),
 					..default()
 				},
 				tonemapping: Tonemapping::BlenderFilmic,

--- a/rs/src/player/camera.rs
+++ b/rs/src/player/camera.rs
@@ -4,9 +4,7 @@ use super::{
 };
 use crate::{planet::sky::SkyShader, player::PlayerId, settings::Settings, NeverDespawn};
 
-use crate::{
-	anim::ComponentDelta, player::prefs::CamSmoothing, util::LerpSlerp,
-};
+use crate::{anim::ComponentDelta, player::prefs::CamSmoothing, util::LerpSlerp};
 use bevy::{
 	core_pipeline::{
 		bloom::BloomSettings, clear_color::ClearColorConfig, fxaa::Fxaa, tonemapping::Tonemapping,

--- a/rs/src/player/camera.rs
+++ b/rs/src/player/camera.rs
@@ -170,7 +170,7 @@ pub fn spawn_pivot<'w, 's, 'a>(
 	let mut cmds = cmds
 		.spawn((
 			owner,
-			CameraVertSlider(0.4),
+			CameraVertSlider::default(),
 			TransformBundle::from_transform(Transform {
 				translation: Vect::new(0.0, 0.0, MIN_CAM_DIST),
 				..default()

--- a/rs/src/player/prefs.rs
+++ b/rs/src/player/prefs.rs
@@ -1,19 +1,16 @@
 use super::input::PlayerAction;
-use crate::player::input::PlayerAction::*;
+use crate::player::{input::PlayerAction::*, player_entity::Root, BelongsToPlayer};
 use bevy::{ecs::query::WorldQuery, prelude::*};
 use bevy_pkv::PkvStore;
 use enum_components::ERef;
 use leafwing_input_manager::prelude::*;
 use serde::{Deserialize, Serialize};
-use crate::player::BelongsToPlayer;
-use crate::player::player_entity::Root;
 
 pub struct PrefsPlugin;
 
 impl Plugin for PrefsPlugin {
 	fn build(&self, app: &mut App) {
-		app
-			.register_type::<InvertCamera>()
+		app.register_type::<InvertCamera>()
 			.register_type::<Fov>()
 			.register_type::<LookSensitivity>()
 			.register_type::<CamSmoothing>()
@@ -48,10 +45,7 @@ pub struct PlayerPrefs {
 	pub input_map: InputMap<PlayerAction>,
 }
 
-pub type ChangedPrefs = Or<(
-	ChangedCameraPrefs,
-	Changed<InputMap<PlayerAction>>,
-)>;
+pub type ChangedPrefs = Or<(ChangedCameraPrefs, Changed<InputMap<PlayerAction>>)>;
 
 pub type ChangedCameraPrefs = Or<(
 	Changed<InvertCamera>,
@@ -164,7 +158,9 @@ impl Default for Fov {
 	}
 }
 
-#[derive(Component, Debug, Clone, Copy, PartialEq, Deref, DerefMut, Serialize, Deserialize, Reflect)]
+#[derive(
+	Component, Debug, Clone, Copy, PartialEq, Deref, DerefMut, Serialize, Deserialize, Reflect,
+)]
 #[serde(default)]
 pub struct LookSensitivity(Vec2);
 
@@ -174,7 +170,9 @@ impl Default for LookSensitivity {
 	}
 }
 
-#[derive(Component, Debug, Clone, Copy, PartialEq, Deref, DerefMut, Serialize, Deserialize, Reflect)]
+#[derive(
+	Component, Debug, Clone, Copy, PartialEq, Deref, DerefMut, Serialize, Deserialize, Reflect,
+)]
 #[serde(default)]
 pub struct CamSmoothing(f32);
 

--- a/rs/src/ui/game_ui.rs
+++ b/rs/src/ui/game_ui.rs
@@ -1,12 +1,7 @@
-use bevy::{
-	app::{App, Update},
-	prelude::{Commands, VisibilityBundle},
-};
+use bevy::prelude::*;
 
 pub fn plugin(app: &mut App) -> &mut App {
 	app.add_systems(Update, setup)
 }
 
-pub fn setup(mut cmds: Commands) {
-	cmds.spawn((VisibilityBundle::default(),));
-}
+pub fn setup(mut cmds: Commands) {}

--- a/rs/src/util.rs
+++ b/rs/src/util.rs
@@ -621,8 +621,8 @@ impl Add<DurationDelta> for Duration {
 	}
 }
 
-#[derive(Component, Resource, Deref, DerefMut)]
-pub struct Prev<T>(T);
+#[derive(Component, Default, Debug, Resource, Deref, DerefMut)]
+pub struct Prev<T>(pub T);
 
 impl<T: Clone> Prev<T> {
 	pub fn update_component(


### PR DESCRIPTION
Automatically generates random 24-byte hashes and computes the base-64 encoding of them. At some point I will enable entering seeds manually. This implementation can accept any UTF8 string and hash it to generate the 24-byte seed, while saving the original string along side it for sharing. I will need some way to detect the difference between auto-generated base-64 hashes and manually-entered strings. I could potentially just try to parse the string as a base-64 hash, falling back to hashing the string if it fails, but I'm considering prepending a special character like `~` to designate a randomly-generated hash.