### PR TITLE
Terrain Querying

### DIFF
--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -3093,7 +3093,7 @@ checksum = "9ba869e17168793186c10ca82c7079a4ffdeac4f1a7d9e755b9491c028180e40"
 dependencies = [
  "num-traits",
  "rand 0.7.3",
- "rand_xorshift",
+ "rand_xorshift 0.2.0",
 ]
 
 [[package]]
@@ -3700,6 +3700,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "range-alloc"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4121,6 +4130,7 @@ dependencies = [
  "bevy_pkv",
  "bevy_rapier3d",
  "bimap",
+ "bytemuck",
  "colored",
  "egui_plot",
  "fixedbitset",
@@ -4131,6 +4141,7 @@ dependencies = [
  "num-traits",
  "ordered-float",
  "rand 0.8.5",
+ "rand_xorshift 0.3.0",
  "rapier3d",
  "ron",
  "serde",

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -4112,6 +4112,7 @@ name = "sond-has"
 version = "0.1.0"
 dependencies = [
  "array-init",
+ "base64 0.21.7",
  "bevy",
  "bevy-inspector-egui",
  "bevy_common_assets",
@@ -4129,6 +4130,7 @@ dependencies = [
  "noise",
  "num-traits",
  "ordered-float",
+ "rand 0.8.5",
  "rapier3d",
  "ron",
  "serde",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -74,6 +74,7 @@ bevy_common_assets = { version = "0.8.0", features = ["ron"] }
 array-init = "2.1.0"
 base64 = "0.21.7"
 bevy_pkv = "0.9.0" # settings
+bytemuck = "1.14.1" # mostly for seeds
 crossbeam = "0.8.2"
 fixedbitset = "0.4.2" # navigation graph edge storage
 futures-lite = "2.1.0" # especially for `yield_now()`
@@ -83,6 +84,7 @@ noise = "0.8.2"
 num-traits = "0.2.17"
 ordered-float = "4.2.0"
 rand = "0.8.5"
+rand_xorshift = "0.3.0"
 ron = "0.8.1"
 static_assertions = "1.1.0"
 serde = "1"
@@ -110,6 +112,7 @@ bevy_common_assets = { workspace = true }
 array-init = { workspace = true }
 base64 = { workspace = true }
 bevy_pkv = { workspace = true }
+bytemuck = { workspace = true }
 fixedbitset = { workspace = true }
 futures-lite = { workspace = true }
 bimap = { workspace = true }
@@ -118,6 +121,7 @@ noise = { workspace = true }
 num-traits = { workspace = true }
 ordered-float = { workspace = true }
 rand = { workspace = true }
+rand_xorshift = { workspace = true }
 ron = { workspace = true }
 static_assertions = { workspace = true }
 serde = { workspace = true }

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -72,6 +72,7 @@ bevy_common_assets = { version = "0.8.0", features = ["ron"] }
 
 # Util
 array-init = "2.1.0"
+base64 = "0.21.7"
 bevy_pkv = "0.9.0" # settings
 crossbeam = "0.8.2"
 fixedbitset = "0.4.2" # navigation graph edge storage
@@ -81,6 +82,7 @@ nanorand = { version = "0.7.0", default-features = false, features = ["std", "wy
 noise = "0.8.2"
 num-traits = "0.2.17"
 ordered-float = "4.2.0"
+rand = "0.8.5"
 ron = "0.8.1"
 static_assertions = "1.1.0"
 serde = "1"
@@ -106,6 +108,7 @@ bevy_common_assets = { workspace = true }
 
 # Util
 array-init = { workspace = true }
+base64 = { workspace = true }
 bevy_pkv = { workspace = true }
 fixedbitset = { workspace = true }
 futures-lite = { workspace = true }
@@ -114,6 +117,7 @@ nanorand = { workspace = true }
 noise = { workspace = true }
 num-traits = { workspace = true }
 ordered-float = { workspace = true }
+rand = { workspace = true }
 ron = { workspace = true }
 static_assertions = { workspace = true }
 serde = { workspace = true }

--- a/rs/assets/shaders/dist_dither.wgsl
+++ b/rs/assets/shaders/dist_dither.wgsl
@@ -36,7 +36,7 @@ fn fragment(
 	let world_dist = length(view.world_position.xyz - in.world_position.xyz);
 	let uv = in.position.xy / 16.0;
 	let thresh = textureSample(matrix_texture, matrix_sampler, uv).x;
-	let d = max(0.0, world_dist - material.start);
+	let d = world_dist - material.start;
 	let range = material.end - material.start;
 	if d > thresh * range {
 		discard;

--- a/rs/src/enemies.rs
+++ b/rs/src/enemies.rs
@@ -1,17 +1,26 @@
-use crate::util::IntoFnPlugin;
+use crate::{enemies::copter::QuadCopterPlugin, util::IntoFnPlugin};
 use bevy::prelude::*;
 use enum_components::EnumComponent;
+use mine::MinePlugin;
 
 pub mod aa;
+pub mod copter;
+#[cfg(feature = "debugging")]
 pub mod dummy;
+pub mod mine;
 
 pub fn plugin(app: &mut App) -> &mut App {
-	app.add_plugins(dummy::plugin.plugfn())
+	#[cfg(feature = "debugging")]
+	app.add_plugins(dummy::plugin.plugfn());
+	app.add_plugins((aa::plugin.plugfn(), MinePlugin, QuadCopterPlugin));
+	app
 }
 
 #[derive(EnumComponent, Reflect)]
 pub enum Enemy {
+	#[cfg(feature = "debugging")]
 	Dummy,
 	AA,
+	Mine,
 	QuadCopter,
 }

--- a/rs/src/enemies/copter.rs
+++ b/rs/src/enemies/copter.rs
@@ -1,0 +1,9 @@
+use bevy::prelude::*;
+
+pub struct QuadCopterPlugin;
+
+impl Plugin for QuadCopterPlugin {
+	fn build(&self, app: &mut App) {
+		//todo
+	}
+}

--- a/rs/src/enemies/mine.rs
+++ b/rs/src/enemies/mine.rs
@@ -1,0 +1,9 @@
+use bevy::prelude::*;
+
+pub struct MinePlugin;
+
+impl Plugin for MinePlugin {
+	fn build(&self, app: &mut App) {
+		//todo
+	}
+}

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -3,11 +3,10 @@
 	windows_subsystem = "windows"
 )]
 
-use crate::mats::BubbleMaterial;
+use crate::mats::MatsPlugin;
 use bevy::{
 	diagnostic::FrameTimeDiagnosticsPlugin,
 	ecs::schedule::{LogLevel, ScheduleBuildSettings},
-	pbr::ExtendedMaterial,
 	prelude::*,
 	render::RenderPlugin,
 	window::PrimaryWindow,
@@ -18,7 +17,7 @@ use bevy_rapier3d::prelude::*;
 use particles::{ParticlesPlugin, Spewer};
 use player::ctrl::CtrlVel;
 use std::{f32::consts::*, fmt::Debug, time::Duration};
-use util::{IntoFnPlugin, RonReflectAssetLoader};
+use util::IntoFnPlugin;
 
 #[allow(unused_imports, clippy::single_component_path_imports)]
 #[cfg(all(debug_assertions, not(target_arch = "wasm32")))]
@@ -111,10 +110,13 @@ pub fn game_plugin(app: &mut App) -> &mut App {
 		RapierPhysicsPlugin::<()>::default().in_schedule(Update),
 		FrameTimeDiagnosticsPlugin,
 		AudioPlugin,
+	))
+	.add_plugins((
 		ParticlesPlugin,
 		AbilitiesPlugin,
 		OffloadingPlugin,
 		SkyPlugin,
+		MatsPlugin,
 		anim::BuiltinAnimations,
 		anim::AnimationPlugin::<Spewer>::PLUGIN,
 		enemies::plugin.plugfn(),
@@ -125,26 +127,13 @@ pub fn game_plugin(app: &mut App) -> &mut App {
 		ui::plugin.plugfn(),
 	))
 	.insert_resource(PkvStore::new_with_qualifier("studio", "sonday", "has"))
-	.add_plugins((MaterialPlugin::<
-		ExtendedMaterial<StandardMaterial, BubbleMaterial>,
-	>::default(),))
 	.add_systems(Startup, startup)
 	.add_systems(
 		Update,
 		(terminal_velocity.before(StepSimulation), fullscreen),
 	)
 	.add_systems(PostUpdate, (despawn_oob,));
-	type BubbleMatExt = ExtendedMaterial<StandardMaterial, BubbleMaterial>;
-	let registry = app.world.get_resource::<AppTypeRegistry>().unwrap().clone();
-	{
-		let mut reg = registry.write();
-		reg.register::<BubbleMaterial>();
-		reg.register::<BubbleMatExt>();
-	}
-	app.register_asset_loader(RonReflectAssetLoader::<BubbleMatExt>::new(
-		registry,
-		vec!["mat.ron"],
-	));
+
 	app
 }
 

--- a/rs/src/mats.rs
+++ b/rs/src/mats.rs
@@ -16,7 +16,7 @@ use bevy::{
 };
 use serde::{Deserialize, Serialize};
 
-pub type StdMatExt<T: MaterialExtension> = ExtendedMaterial<StandardMaterial, T>;
+pub type StdMatExt<T> = ExtendedMaterial<StandardMaterial, T>;
 
 pub struct MatsPlugin;
 

--- a/rs/src/planet.rs
+++ b/rs/src/planet.rs
@@ -234,289 +234,140 @@ impl Sub<Vec2> for PlanetVec2 {
 }
 
 pub mod seeds {
-	use crate::planet::terrain;
-	use base64::{engine::general_purpose::URL_SAFE, prelude::*, DecodeError, DecodeSliceError};
+	use base64::{engine::general_purpose::URL_SAFE, prelude::*, DecodeSliceError};
 	use bevy::{
-		log::{error, trace, warn},
 		prelude::Resource,
+		utils::{AHasher, RandomState},
 	};
-	use rand::random;
-	use std::fmt::{Display, Formatter};
+	use rand::{distributions::Standard, prelude::Distribution, Rng};
+	use std::{
+		borrow::Cow,
+		fmt::{Display, Formatter},
+		hash::{BuildHasher, Hash, Hasher},
+	};
 
-	#[derive(Resource, Debug, Copy, Clone, Default, PartialEq, Eq, Hash)]
-	#[repr(C)]
+	#[derive(Resource, Debug, Clone)]
 	pub struct PlanetSeed {
-		pub tera: TerrainSeeds,
+		string: Cow<'static, str>,
+		hash: [u8; 24],
 	}
 
-	impl PlanetSeed {
-		pub const BASE64_CHARS: usize = TerrainSeeds::BASE64_CHARS;
-
-		pub fn base64(self) -> [u8; Self::BASE64_CHARS] {
-			self.tera.base64()
+	impl PartialEq for PlanetSeed {
+		fn eq(&self, other: &Self) -> bool {
+			self.hash == other.hash
 		}
+	}
 
-		pub fn from_base64(bytes: impl AsRef<[u8]>) -> Result<Self, DecodeError> {
-			TerrainSeeds::from_base64(bytes.as_ref()).map(|(tera, rest)| {
-				if rest.len() > 0 {
-					warn!(
-						"Undecoded base64 characters: {}",
-						String::from_utf8_lossy(rest)
-					);
-				}
-				Self { tera }
-			})
+	impl Distribution<PlanetSeed> for Standard {
+		fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> PlanetSeed {
+			let hash = rng.gen::<[u8; 24]>();
+			let string = Cow::from(URL_SAFE.encode(hash));
+
+			PlanetSeed { string, hash }
+		}
+	}
+
+	impl<S: Into<Cow<'static, str>>> From<S> for PlanetSeed {
+		fn from(value: S) -> Self {
+			let string = value.into();
+			let bytes = string.as_bytes();
+			let bytes = if bytes.len() > Self::MAX_INPUT_LEN {
+				bytes.split_at(Self::MAX_INPUT_LEN).0
+			} else {
+				bytes
+			};
+
+			let mut hash = [0u8; 24];
+
+			// Randomly generated during development.
+			// WARNING: Changing these will break compatibility with older seeds.
+			let mut hasher = RandomState::with_seeds(
+				8171301572015878809,
+				11868435174398743204,
+				12156415504192146545,
+				13548443979666687785,
+			)
+			.build_hasher();
+			hasher.write(bytes);
+			hash[0..8].copy_from_slice(&hasher.finish().to_le_bytes());
+
+			hasher.write(bytes);
+			hash[8..16].copy_from_slice(&hasher.finish().to_le_bytes());
+
+			hasher.write(bytes);
+			hash[16..24].copy_from_slice(&hasher.finish().to_le_bytes());
+
+			Self { string, hash }
 		}
 	}
 
 	impl Display for PlanetSeed {
 		fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-			f.write_str(std::str::from_utf8(&self.base64()).unwrap())
+			self.string.fmt(f)
 		}
 	}
 
-	#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-	#[repr(C)]
-	pub struct TerrainSeeds {
-		pub base: u32,
-		perlin: HSSeed,
-		worley: HSSeed,
-		billow: HSSeed,
-		ridged: HSSeed,
-	}
+	impl PlanetSeed {
+		/// Maximum number of characters that will be hashed from the input string.
+		// WARNING: Changing this will break compatibility with some older seeds.
+		pub const MAX_INPUT_LEN: usize = 128;
 
-	const fn base64_chars(bytes: usize) -> usize {
-		bytes.div_ceil(3) * 4
-	}
-	const _ASSERT4: [u8; 8] = [0; base64_chars(4)];
-	const _ASSERT7: [u8; 12] = [0; base64_chars(7)];
-
-	impl TerrainSeeds {
-		/// Number of noise sources.
-		pub const LEN: u8 = 4;
-
-		/// Number of base64 characters to encode [Self::LEN].
-		pub const LEN_CHARS: usize = 4;
-		/// Number of base64 characters to encode [Self::base].
-		pub const BASE_CHARS: usize = base64_chars(4);
-		/// Number of base64 characters to encode all source seeds.
-		pub const SOURCES_CHARS: usize =
-			base64_chars(std::mem::size_of::<HSSeed>() * Self::LEN as usize);
-		/// Total number of base64 characters to encode `Self`.
-		pub const BASE64_CHARS: usize = Self::LEN_CHARS + Self::BASE_CHARS + Self::SOURCES_CHARS;
-
-		pub fn base64(&self) -> [u8; Self::BASE64_CHARS] {
-			let mut ret = [0u8; Self::BASE64_CHARS];
-
-			{
-				let (len, ret) = ret.split_at_mut(Self::LEN_CHARS);
-				URL_SAFE.encode_slice(&[Self::LEN], len).unwrap();
-				let (base, ret) = ret.split_at_mut(Self::BASE_CHARS);
-				URL_SAFE
-					.encode_slice(self.base.to_le_bytes(), base)
-					.unwrap();
-				let sources_bytes = [
-					self.perlin.bytes(),
-					self.worley.bytes(),
-					self.billow.bytes(),
-					self.ridged.bytes(),
-				];
-				let sources_bytes = unsafe {
-					std::mem::transmute::<
-						_,
-						&[u8; Self::LEN as usize * std::mem::size_of::<HSSeed>()],
-					>(&sources_bytes)
-				};
-				let n = URL_SAFE.encode_slice(sources_bytes, ret).unwrap();
-				debug_assert_eq!(n, ret.len());
-			}
-
-			ret
+		pub fn string(&self) -> &Cow<'static, str> {
+			&self.string
 		}
 
-		pub fn from_base64(bytes: &[u8]) -> Result<(Self, &[u8]), DecodeError> {
-			let (len, rest) = bytes.split_at(Self::LEN_CHARS);
-			let mut buf = [u8::MAX; 3];
-			let n = URL_SAFE.decode_slice(len, &mut buf).map_err(|e| match e {
-				DecodeSliceError::DecodeError(e) => e,
-				DecodeSliceError::OutputSliceTooSmall => unreachable!(),
-			})?;
-			debug_assert_eq!(n, 1);
-			let len = buf[0];
-			if len != Self::LEN {
-				warn!("Seed is from a different version. Making a best-effort conversion.");
-			}
+		/// Transforms self into its canonical representation, with the string being the base64
+		/// encoding of its hash.
+		pub fn canonical(mut self) -> Self {
+			self.make_canonical();
+			self
+		}
 
-			let (base, rest) = rest.split_at(Self::BASE_CHARS);
-			let mut buf = [0u8; 4];
-			let n = URL_SAFE.decode_slice_unchecked(base, &mut buf)?;
-			debug_assert_eq!(n, 4);
-			let base = u32::from_le_bytes(buf);
-
-			let sources_chars = usize::min(Self::SOURCES_CHARS, rest.len());
-			let (sources, rest) = rest.split_at(sources_chars);
-			const SOURCES_BYTES: usize = std::mem::size_of::<HSSeed>() * TerrainSeeds::LEN as usize;
-			let mut buf = [u8::MAX; SOURCES_BYTES + 2];
-			match URL_SAFE.decode_slice(sources, &mut buf) {
-				Ok(n) => debug_assert_eq!(n, SOURCES_BYTES),
-				Err(DecodeSliceError::OutputSliceTooSmall) => unreachable!(),
-				Err(DecodeSliceError::DecodeError(e)) => return Err(e),
-			}
-			let buf = unsafe {
-				&*(&buf as *const _
-					as *const [[u8; std::mem::size_of::<HSSeed>()]; Self::LEN as usize])
+		/// Replaces the string representation of self with the canonical base64 encoding of its hash.
+		pub fn make_canonical(&mut self) {
+			let Self { string, hash } = self;
+			let mut canonical = String::with_capacity(32);
+			URL_SAFE.encode_string(hash, &mut canonical);
+			debug_assert_eq!(canonical.len(), 32);
+			if *string != canonical {
+				*string.to_mut() = canonical;
 			};
-
-			Ok((
-				Self {
-					base,
-					perlin: HSSeed::from_bytes(buf[0]),
-					worley: HSSeed::from_bytes(buf[1]),
-					billow: HSSeed::from_bytes(buf[2]),
-					ridged: HSSeed::from_bytes(buf[3]),
-				},
-				rest,
-			))
 		}
 
-		pub fn perlin(&self) -> HSSeed {
-			self.perlin
-		}
-		pub fn worley(&self) -> HSSeed {
-			self.worley
-		}
-		pub fn billow(&self) -> HSSeed {
-			self.billow
-		}
-		pub fn ridged(&self) -> HSSeed {
-			self.ridged
-		}
-	}
-
-	impl Default for TerrainSeeds {
-		fn default() -> Self {
-			let [perlin, worley, billow, ridged] = HSSeed::many_best_effort();
-			Self {
-				base: random(),
-				perlin,
-				worley,
-				billow,
-				ridged,
-			}
-		}
-	}
-
-	/// Combined heights and strength seed for [ChooseAndSmooth](terrain::noise::ChooseAndSmooth)
-	#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-	#[repr(C)]
-	pub struct HSSeed {
-		heights: u32,
-		strength: u32,
-	}
-
-	impl HSSeed {
-		/// Changing the size of `HSSeed` will break compatibility with older seeds.
-		const _ASSERT_SIZE_8: [u8; 8] = [0; std::mem::size_of::<Self>()];
-
-		pub fn try_not_clashing_with(others: &[u32], attempts: usize) -> Option<Self> {
-			let mut s = random();
-			for _ in 0..attempts {
-				if !others.contains(&s) {
-					return Some(Self {
-						heights: random(),
-						strength: s,
-					});
-				} else {
-					trace!("{} clashes with [{}]", URL_SAFE.encode(s.to_le_bytes()), {
-						let mut encoded = String::with_capacity((others.len() * 4).div_ceil(3));
-						for other in others {
-							URL_SAFE.encode_string(other.to_le_bytes(), &mut encoded);
-						}
-						encoded
-					});
-					s = random();
-				}
-			}
-			None
+		pub fn hash(&self) -> &[u8; 24] {
+			&self.hash
 		}
 
-		pub fn best_effort(others: &[u32]) -> Self {
-			const ATTEMPTS: usize = 1024;
-			Self::try_not_clashing_with(others, ATTEMPTS).unwrap_or_else(|| {
-				let s = random();
-				if others.contains(&s) {
-					let mut encoded = String::with_capacity((others.len() * 4).div_ceil(3));
-					for other in others {
-						URL_SAFE.encode_string(other.to_le_bytes(), &mut encoded);
-					}
-					error!(
-						"Couldn't find a non-clashing strength seed in {ATTEMPTS} attempts. \
-					Using {} despite it clashing with [{encoded}].",
-						URL_SAFE.encode(s.to_le_bytes())
-					);
-				} else {
-					trace!(
-						"One last attempt found {}",
-						URL_SAFE.encode(s.to_le_bytes())
-					);
-				}
-				Self {
-					heights: random(),
-					strength: s,
-				}
-			})
-		}
-
-		pub fn many_best_effort<const LEN: usize>() -> [Self; LEN] {
-			let mut ret = [Self {
-				heights: 0,
-				strength: 0,
-			}; LEN];
-			let mut buf = [0; LEN];
-			for i in 0..LEN {
-				let new = Self::best_effort(&buf[0..i]);
-				ret[i] = new;
-				buf[i] = new.strength;
-			}
-			ret
-		}
-
-		pub fn bytes(self) -> [u8; std::mem::size_of::<Self>()] {
-			unsafe {
-				// All std ways of doing this are either unstable or work with slices instead of arrays
-				std::mem::transmute([self.heights.to_le_bytes(), self.strength.to_le_bytes()])
-			}
-		}
-
-		pub fn from_bytes(bytes: [u8; std::mem::size_of::<Self>()]) -> Self {
-			let [heights, strength] = unsafe {
-				// All std ways of doing this are either unstable or work with slices instead of arrays
-				std::mem::transmute(bytes)
-			};
-			Self {
-				heights: u32::from_le_bytes(heights),
-				strength: u32::from_le_bytes(strength),
-			}
-		}
-
-		pub fn heights(&self) -> u32 {
-			self.heights
-		}
-		pub fn strength(&self) -> u32 {
-			self.strength
+		pub fn from_canonical(
+			canonical: impl Into<Cow<'static, str>>,
+		) -> Result<Self, DecodeSliceError> {
+			let string = canonical.into();
+			assert_eq!(string.len(), 32);
+			let mut hash = [0; 24];
+			URL_SAFE.decode_slice(&*string, &mut hash)?;
+			Ok(Self { string, hash })
 		}
 	}
 
 	#[cfg(test)]
 	mod tests {
-		use crate::planet::seeds::PlanetSeed;
+		use super::PlanetSeed;
 
 		#[test]
-		fn seed_base64_round_trip() {
-			let seed = PlanetSeed::default();
-			let encoded = seed.base64();
-			let decoded = PlanetSeed::from_base64(encoded);
-			assert_eq!(Ok(seed), decoded);
+		fn canonical_equivalence() {
+			let seed = PlanetSeed::from("This is a test seed for canonical equivalence.");
+			let (seed, canonical) = (seed.clone(), seed.canonical());
+			assert_ne!(seed.string, canonical.string);
+			assert_eq!(seed, canonical);
+		}
+
+		#[test]
+		fn version_equivalence() {
+			const S: &str = "This is a test seed for seed consistency across game versions";
+			const CANON: &str = "EMVUkEmSHysISOFRcpRyoTWjBDYE3IgV";
+			let seed = PlanetSeed::from(S);
+			let canonical = PlanetSeed::from_canonical(CANON).unwrap();
+			assert_eq!(seed, canonical);
 		}
 	}
 }

--- a/rs/src/planet.rs
+++ b/rs/src/planet.rs
@@ -232,3 +232,291 @@ impl Sub<Vec2> for PlanetVec2 {
 		Self::from(*self - rhs)
 	}
 }
+
+pub mod seeds {
+	use crate::planet::terrain;
+	use base64::{engine::general_purpose::URL_SAFE, prelude::*, DecodeError, DecodeSliceError};
+	use bevy::{
+		log::{error, trace, warn},
+		prelude::Resource,
+	};
+	use rand::random;
+	use std::fmt::{Display, Formatter};
+
+	#[derive(Resource, Debug, Copy, Clone, Default, PartialEq, Eq, Hash)]
+	#[repr(C)]
+	pub struct PlanetSeed {
+		pub tera: TerrainSeeds,
+	}
+
+	impl PlanetSeed {
+		pub const BASE64_CHARS: usize = TerrainSeeds::BASE64_CHARS;
+
+		pub fn base64(self) -> [u8; Self::BASE64_CHARS] {
+			self.tera.base64()
+		}
+
+		pub fn from_base64(bytes: impl AsRef<[u8]>) -> Result<Self, DecodeError> {
+			TerrainSeeds::from_base64(bytes.as_ref()).map(|(tera, rest)| {
+				if rest.len() > 0 {
+					warn!(
+						"Undecoded base64 characters: {}",
+						String::from_utf8_lossy(rest)
+					);
+				}
+				Self { tera }
+			})
+		}
+	}
+
+	impl Display for PlanetSeed {
+		fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+			f.write_str(std::str::from_utf8(&self.base64()).unwrap())
+		}
+	}
+
+	#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+	#[repr(C)]
+	pub struct TerrainSeeds {
+		pub base: u32,
+		perlin: HSSeed,
+		worley: HSSeed,
+		billow: HSSeed,
+		ridged: HSSeed,
+	}
+
+	const fn base64_chars(bytes: usize) -> usize {
+		bytes.div_ceil(3) * 4
+	}
+	const _ASSERT4: [u8; 8] = [0; base64_chars(4)];
+	const _ASSERT7: [u8; 12] = [0; base64_chars(7)];
+
+	impl TerrainSeeds {
+		/// Number of noise sources.
+		pub const LEN: u8 = 4;
+
+		/// Number of base64 characters to encode [Self::LEN].
+		pub const LEN_CHARS: usize = 4;
+		/// Number of base64 characters to encode [Self::base].
+		pub const BASE_CHARS: usize = base64_chars(4);
+		/// Number of base64 characters to encode all source seeds.
+		pub const SOURCES_CHARS: usize =
+			base64_chars(std::mem::size_of::<HSSeed>() * Self::LEN as usize);
+		/// Total number of base64 characters to encode `Self`.
+		pub const BASE64_CHARS: usize = Self::LEN_CHARS + Self::BASE_CHARS + Self::SOURCES_CHARS;
+
+		pub fn base64(&self) -> [u8; Self::BASE64_CHARS] {
+			let mut ret = [0u8; Self::BASE64_CHARS];
+
+			{
+				let (len, ret) = ret.split_at_mut(Self::LEN_CHARS);
+				URL_SAFE.encode_slice(&[Self::LEN], len).unwrap();
+				let (base, ret) = ret.split_at_mut(Self::BASE_CHARS);
+				URL_SAFE
+					.encode_slice(self.base.to_le_bytes(), base)
+					.unwrap();
+				let sources_bytes = [
+					self.perlin.bytes(),
+					self.worley.bytes(),
+					self.billow.bytes(),
+					self.ridged.bytes(),
+				];
+				let sources_bytes = unsafe {
+					std::mem::transmute::<
+						_,
+						&[u8; Self::LEN as usize * std::mem::size_of::<HSSeed>()],
+					>(&sources_bytes)
+				};
+				let n = URL_SAFE.encode_slice(sources_bytes, ret).unwrap();
+				debug_assert_eq!(n, ret.len());
+			}
+
+			ret
+		}
+
+		pub fn from_base64(bytes: &[u8]) -> Result<(Self, &[u8]), DecodeError> {
+			let (len, rest) = bytes.split_at(Self::LEN_CHARS);
+			let mut buf = [u8::MAX; 3];
+			let n = URL_SAFE.decode_slice(len, &mut buf).map_err(|e| match e {
+				DecodeSliceError::DecodeError(e) => e,
+				DecodeSliceError::OutputSliceTooSmall => unreachable!(),
+			})?;
+			debug_assert_eq!(n, 1);
+			let len = buf[0];
+			if len != Self::LEN {
+				warn!("Seed is from a different version. Making a best-effort conversion.");
+			}
+
+			let (base, rest) = rest.split_at(Self::BASE_CHARS);
+			let mut buf = [0u8; 4];
+			let n = URL_SAFE.decode_slice_unchecked(base, &mut buf)?;
+			debug_assert_eq!(n, 4);
+			let base = u32::from_le_bytes(buf);
+
+			let sources_chars = usize::min(Self::SOURCES_CHARS, rest.len());
+			let (sources, rest) = rest.split_at(sources_chars);
+			const SOURCES_BYTES: usize = std::mem::size_of::<HSSeed>() * TerrainSeeds::LEN as usize;
+			let mut buf = [u8::MAX; SOURCES_BYTES + 2];
+			match URL_SAFE.decode_slice(sources, &mut buf) {
+				Ok(n) => debug_assert_eq!(n, SOURCES_BYTES),
+				Err(DecodeSliceError::OutputSliceTooSmall) => unreachable!(),
+				Err(DecodeSliceError::DecodeError(e)) => return Err(e),
+			}
+			let buf = unsafe {
+				&*(&buf as *const _
+					as *const [[u8; std::mem::size_of::<HSSeed>()]; Self::LEN as usize])
+			};
+
+			Ok((
+				Self {
+					base,
+					perlin: HSSeed::from_bytes(buf[0]),
+					worley: HSSeed::from_bytes(buf[1]),
+					billow: HSSeed::from_bytes(buf[2]),
+					ridged: HSSeed::from_bytes(buf[3]),
+				},
+				rest,
+			))
+		}
+
+		pub fn perlin(&self) -> HSSeed {
+			self.perlin
+		}
+		pub fn worley(&self) -> HSSeed {
+			self.worley
+		}
+		pub fn billow(&self) -> HSSeed {
+			self.billow
+		}
+		pub fn ridged(&self) -> HSSeed {
+			self.ridged
+		}
+	}
+
+	impl Default for TerrainSeeds {
+		fn default() -> Self {
+			let [perlin, worley, billow, ridged] = HSSeed::many_best_effort();
+			Self {
+				base: random(),
+				perlin,
+				worley,
+				billow,
+				ridged,
+			}
+		}
+	}
+
+	/// Combined heights and strength seed for [ChooseAndSmooth](terrain::noise::ChooseAndSmooth)
+	#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+	#[repr(C)]
+	pub struct HSSeed {
+		heights: u32,
+		strength: u32,
+	}
+
+	impl HSSeed {
+		/// Changing the size of `HSSeed` will break compatibility with older seeds.
+		const _ASSERT_SIZE_8: [u8; 8] = [0; std::mem::size_of::<Self>()];
+
+		pub fn try_not_clashing_with(others: &[u32], attempts: usize) -> Option<Self> {
+			let mut s = random();
+			for _ in 0..attempts {
+				if !others.contains(&s) {
+					return Some(Self {
+						heights: random(),
+						strength: s,
+					});
+				} else {
+					trace!("{} clashes with [{}]", URL_SAFE.encode(s.to_le_bytes()), {
+						let mut encoded = String::with_capacity((others.len() * 4).div_ceil(3));
+						for other in others {
+							URL_SAFE.encode_string(other.to_le_bytes(), &mut encoded);
+						}
+						encoded
+					});
+					s = random();
+				}
+			}
+			None
+		}
+
+		pub fn best_effort(others: &[u32]) -> Self {
+			const ATTEMPTS: usize = 1024;
+			Self::try_not_clashing_with(others, ATTEMPTS).unwrap_or_else(|| {
+				let s = random();
+				if others.contains(&s) {
+					let mut encoded = String::with_capacity((others.len() * 4).div_ceil(3));
+					for other in others {
+						URL_SAFE.encode_string(other.to_le_bytes(), &mut encoded);
+					}
+					error!(
+						"Couldn't find a non-clashing strength seed in {ATTEMPTS} attempts. \
+					Using {} despite it clashing with [{encoded}].",
+						URL_SAFE.encode(s.to_le_bytes())
+					);
+				} else {
+					trace!(
+						"One last attempt found {}",
+						URL_SAFE.encode(s.to_le_bytes())
+					);
+				}
+				Self {
+					heights: random(),
+					strength: s,
+				}
+			})
+		}
+
+		pub fn many_best_effort<const LEN: usize>() -> [Self; LEN] {
+			let mut ret = [Self {
+				heights: 0,
+				strength: 0,
+			}; LEN];
+			let mut buf = [0; LEN];
+			for i in 0..LEN {
+				let new = Self::best_effort(&buf[0..i]);
+				ret[i] = new;
+				buf[i] = new.strength;
+			}
+			ret
+		}
+
+		pub fn bytes(self) -> [u8; std::mem::size_of::<Self>()] {
+			unsafe {
+				// All std ways of doing this are either unstable or work with slices instead of arrays
+				std::mem::transmute([self.heights.to_le_bytes(), self.strength.to_le_bytes()])
+			}
+		}
+
+		pub fn from_bytes(bytes: [u8; std::mem::size_of::<Self>()]) -> Self {
+			let [heights, strength] = unsafe {
+				// All std ways of doing this are either unstable or work with slices instead of arrays
+				std::mem::transmute(bytes)
+			};
+			Self {
+				heights: u32::from_le_bytes(heights),
+				strength: u32::from_le_bytes(strength),
+			}
+		}
+
+		pub fn heights(&self) -> u32 {
+			self.heights
+		}
+		pub fn strength(&self) -> u32 {
+			self.strength
+		}
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use crate::planet::seeds::PlanetSeed;
+
+		#[test]
+		fn seed_base64_round_trip() {
+			let seed = PlanetSeed::default();
+			let encoded = seed.base64();
+			let decoded = PlanetSeed::from_base64(encoded);
+			assert_eq!(Ok(seed), decoded);
+		}
+	}
+}

--- a/rs/src/planet/chunks.rs
+++ b/rs/src/planet/chunks.rs
@@ -1,3 +1,4 @@
+use bevy::ecs::system::SystemParam;
 use super::terrain::Ground;
 use crate::{
 	nav::heightmap::{FnsThatShouldBePub, TriId},
@@ -110,5 +111,38 @@ impl LoadedChunks {
 		let (center, ground) = grounds.get(*self.get_by_left(&chunk)?).ok()?;
 		let rel = point.delta_from(&**center);
 		ground.tri_and_height_at(rel)
+	}
+}
+
+#[derive(SystemParam)]
+pub struct ChunkFinder<'w, 's> {
+	pub loaded_chunks: Res<'w, LoadedChunks>,
+	pub grounds: Query<'w, 's, (&'static ChunkCenter, &'static Ground)>,
+}
+
+impl ChunkFinder<'_, '_> {
+	pub fn closest_to(&self, point: PlanetVec2) -> Option<(ChunkIndex, Entity)> {
+		self.loaded_chunks.closest_to(point)
+	}
+	
+	pub fn tri_at(
+		&self,
+		point: PlanetVec2,
+	) -> Option<(TriId, Triangle)> {
+		self.loaded_chunks.tri_at(point, &self.grounds)
+	}
+	
+	pub fn height_at(
+		&self,
+		point: PlanetVec2,
+	) -> Option<f32> {
+		self.loaded_chunks.height_at(point, &self.grounds)
+	}
+	
+	pub fn tri_and_height_at(
+		&self,
+		point: PlanetVec2,
+	) -> Option<(TriId, f32)> {
+		self.loaded_chunks.tri_and_height_at(point, &self.grounds)
 	}
 }

--- a/rs/src/planet/chunks.rs
+++ b/rs/src/planet/chunks.rs
@@ -1,11 +1,10 @@
-use bevy::ecs::system::SystemParam;
 use super::terrain::Ground;
 use crate::{
 	nav::heightmap::{FnsThatShouldBePub, TriId},
 	planet::PlanetVec2,
 	util::Diff,
 };
-use bevy::prelude::*;
+use bevy::{ecs::system::SystemParam, prelude::*};
 use bevy_rapier3d::{
 	na::{Point3, Vector3},
 	parry::{query::PointQuery, shape::Triangle},
@@ -124,25 +123,16 @@ impl ChunkFinder<'_, '_> {
 	pub fn closest_to(&self, point: PlanetVec2) -> Option<(ChunkIndex, Entity)> {
 		self.loaded_chunks.closest_to(point)
 	}
-	
-	pub fn tri_at(
-		&self,
-		point: PlanetVec2,
-	) -> Option<(TriId, Triangle)> {
+
+	pub fn tri_at(&self, point: PlanetVec2) -> Option<(TriId, Triangle)> {
 		self.loaded_chunks.tri_at(point, &self.grounds)
 	}
-	
-	pub fn height_at(
-		&self,
-		point: PlanetVec2,
-	) -> Option<f32> {
+
+	pub fn height_at(&self, point: PlanetVec2) -> Option<f32> {
 		self.loaded_chunks.height_at(point, &self.grounds)
 	}
-	
-	pub fn tri_and_height_at(
-		&self,
-		point: PlanetVec2,
-	) -> Option<(TriId, f32)> {
+
+	pub fn tri_and_height_at(&self, point: PlanetVec2) -> Option<(TriId, f32)> {
 		self.loaded_chunks.tri_and_height_at(point, &self.grounds)
 	}
 }

--- a/rs/src/planet/chunks.rs
+++ b/rs/src/planet/chunks.rs
@@ -1,5 +1,9 @@
 use super::terrain::Ground;
-use crate::{nav::heightmap::FnsThatShouldBePub, planet::PlanetVec2, util::Diff};
+use crate::{
+	nav::heightmap::{FnsThatShouldBePub, TriId},
+	planet::PlanetVec2,
+	util::Diff,
+};
 use bevy::prelude::*;
 use bevy_rapier3d::{
 	na::{Point3, Vector3},
@@ -77,70 +81,34 @@ impl LoadedChunks {
 			.min_by_key(|(index, id)| index.manhattan_dist(maybe_loaded))
 	}
 
+	pub fn tri_at(
+		&self,
+		point: PlanetVec2,
+		grounds: &Query<(&ChunkCenter, &Ground)>,
+	) -> Option<(TriId, Triangle)> {
+		let chunk = ChunkIndex::from(point);
+		let (center, ground) = grounds.get(*self.get_by_left(&chunk)?).ok()?;
+		let rel = point.delta_from(&**center);
+		ground.tri_at(rel)
+	}
+
 	pub fn height_at(
 		&self,
 		point: PlanetVec2,
 		grounds: &Query<(&ChunkCenter, &Ground)>,
 	) -> Option<f32> {
+		self.tri_and_height_at(point, grounds)
+			.map(|(_, height)| height)
+	}
+
+	pub fn tri_and_height_at(
+		&self,
+		point: PlanetVec2,
+		grounds: &Query<(&ChunkCenter, &Ground)>,
+	) -> Option<(TriId, f32)> {
 		let chunk = ChunkIndex::from(point);
 		let (center, ground) = grounds.get(*self.get_by_left(&chunk)?).ok()?;
 		let rel = point.delta_from(&**center);
-		let rel = Vec2::new(rel.x, -rel.y);
-		let point = Point3::new(rel.x, 0.0, rel.y);
-		let (i, j) = ground.heights.cell_at_point(&point)?;
-		let (left, right) = ground.heights.triangles_at(i, j);
-		
-		// ZIG-ZAG
-		// a -- c  c
-		// | L / / |
-		// |  / /  |
-		// | / / R |
-		// b  a -- b
-		//
-		// NORMAL
-		// a  a -- c
-		// | \ \ R |
-		// |  \ \  |
-		// | L \ \ |
-		// b -- c  b
-		//
-		let tri = match (left, right) {
-			(Some(left), Some(right)) => {
-				let status = ground.heights.cell_status(i, j);
-				let (l, r) = if status.contains(HeightFieldCellStatus::ZIGZAG_SUBDIVISION) {
-					debug_assert!({
-						let p = left.a - right.a;
-						p.x * p.x + p.y * p.y + p.z * p.z
-					} <= f32::EPSILON);
-					(left.a.xy(), right.b.xy())
-				} else {
-					debug_assert!({
-						let p = left.c - right.c;
-						p.x * p.x + p.y * p.y + p.z * p.z
-					} <= f32::EPSILON);
-					(left.b.xy(), right.c.xy())
-				};
-				// Checking the squared distances to the opposing points is at least as cheap as any other solution.
-				let p = point.xy();
-				let dl = l - p.xy();
-				let dr = r - p.xy();
-				let dl = dl.x * dl.x + dl.y * dl.y;
-				let dr = dr.x * dr.x + dr.y * dr.y;
-				if dl < dr {
-					left
-				} else {
-					right
-				}
-			}
-			(None, Some(right)) => right,
-			(Some(left), None) => left,
-			(None, None) => return None,
-		};
-		
-		let da = TERRAIN_CELL_SIZE - (Vec2::from(tri.a.xz()) - rel).length();
-		let db = TERRAIN_CELL_SIZE - (Vec2::from(tri.b.xz()) - rel).length();
-		let dc = TERRAIN_CELL_SIZE - (Vec2::from(tri.c.xz()) - rel).length();
-		let sum = da + db + dc;
-		Some((da / sum) * tri.a.y + (db / sum) * tri.b.y + (dc / sum) * tri.c.y)
+		ground.tri_and_height_at(rel)
 	}
 }

--- a/rs/src/planet/terrain.rs
+++ b/rs/src/planet/terrain.rs
@@ -9,7 +9,10 @@ use crate::{
 		},
 		frame::Frame,
 		seeds::PlanetSeed,
-		terrain::noise::{ChooseAndSmooth, Source, SyncWorley},
+		terrain::{
+			noise::{ChooseAndSmooth, Source, SyncWorley},
+			seeds::TerrainSeeds,
+		},
 		PlanetVec2,
 	},
 	player::player_entity::Root,
@@ -59,93 +62,10 @@ pub fn setup(
 	let material = assets.load("shaders/terrain.mat.ron");
 
 	cmds.insert_resource(TerrainMaterial(material.clone()));
-	let seeds = PlanetSeed::default();
-	info!(name: "seed", seed = %seeds);
-	let seeds = seeds.tera;
+	let seed = rand::random::<PlanetSeed>();
+	info!(name: "seed", seed = %seed);
 
-	// Add is not Clone, so we'll use a closure to get multiple copies
-	let base = || {
-		Add::new(
-			ScaleBias::new(
-				HybridMulti::<Value>::default()
-					.set_frequency(0.00032)
-					.set_persistence(0.5),
-			)
-			.set_scale(2.0),
-			Fbm::<Perlin>::default()
-				.set_frequency(0.00128)
-				.set_octaves(2)
-				.set_persistence(0.45)
-				.set_seed(seeds.base),
-		)
-	};
-
-	let strength_noise = Fbm::<Perlin>::default()
-		.set_frequency(0.00128)
-		.set_octaves(2)
-		.set_seed(seeds.perlin().strength());
-
-	let perlin = Source::new(
-		Add::new(
-			ScaleBias::new(
-				Fbm::<Perlin>::default()
-					.set_frequency(0.0256)
-					.set_persistence(0.45)
-					.set_seed(seeds.perlin().heights()),
-			)
-			.set_scale(0.05),
-			base(),
-		),
-		strength_noise.clone(),
-		// Constant::new(-1.0),
-	);
-
-	let worley = Source::new(
-		Add::new(
-			ScaleBias::new(
-				SyncWorley::default()
-					.set_frequency(0.05)
-					.set_seed(seeds.worley().heights()),
-			)
-			.set_scale(0.1),
-			base(),
-		),
-		strength_noise.clone().set_seed(seeds.worley().strength()),
-		// Constant::new(-1.0),
-	);
-
-	let billow = Source::new(
-		Add::new(
-			ScaleBias::new(
-				Billow::<Perlin>::default()
-					.set_frequency(0.02)
-					.set_octaves(2)
-					.set_seed(seeds.billow().heights()),
-			)
-			.set_scale(0.04),
-			base(),
-		),
-		strength_noise.clone().set_seed(seeds.billow().strength()),
-		// Constant::new(-1.0),
-	);
-
-	let ridged = Source::new(
-		Add::new(
-			ScaleBias::new(
-				RidgedMulti::<Perlin>::default()
-					.set_frequency(0.02)
-					.set_seed(seeds.ridged().heights()),
-			)
-			.set_scale(0.07),
-			base(),
-		),
-		strength_noise.clone().set_seed(seeds.ridged().strength()),
-		// Constant::new(-1.0),
-	);
-
-	let noise = ChooseAndSmooth::new([perlin, worley, billow, ridged]);
-
-	let noise = PlanetHeightSource::new(noise);
+	let noise = PlanetHeightSource::generate((&seed).into());
 
 	// Spawn center first
 	generate_chunk(
@@ -156,6 +76,7 @@ pub fn setup(
 		&mut task_offloader,
 	);
 
+	cmds.insert_resource(seed);
 	cmds.insert_resource(noise);
 
 	let mesh = Mesh::from(shape::Cube { size: 64.0 })
@@ -323,6 +244,98 @@ impl PlanetHeightSource {
 			noise: noise.into(),
 		}
 	}
+
+	pub fn generate(seeds: TerrainSeeds) -> Self {
+		let base = bytemuck::cast::<_, [u32; 2]>(seeds.base());
+		let perlin = Perlin::default().set_seed(base[0]);
+		let sources = vec![perlin, perlin.set_seed(base[1])];
+
+		// unfortunately this generates sources that are immediately discarded, but `sources` isn't pub
+		let mut base = Fbm::<Perlin>::default();
+		base.octaves = 2;
+		base.frequency = 0.00128;
+		base.persistence = 0.45;
+		let base = base.set_sources(sources);
+
+		// Add and ScaleBias are not Clone, so we'll use a closure to get multiple copies
+		let base = || {
+			Add::new(
+				ScaleBias::new(
+					HybridMulti::<Value>::default()
+						.set_frequency(0.00032)
+						.set_persistence(0.5),
+				)
+				.set_scale(2.0),
+				base.clone(),
+			)
+		};
+
+		let strength_noise = Fbm::<Perlin>::default()
+			.set_frequency(0.00128)
+			.set_octaves(2)
+			.set_seed(seeds.perlin().strength());
+
+		let perlin = Source::new(
+			Add::new(
+				ScaleBias::new(
+					Fbm::<Perlin>::default()
+						.set_frequency(0.0256)
+						.set_persistence(0.45)
+						.set_seed(seeds.perlin().heights()),
+				)
+				.set_scale(0.05),
+				base(),
+			),
+			strength_noise.clone(),
+			// Constant::new(-1.0),
+		);
+
+		let worley = Source::new(
+			Add::new(
+				ScaleBias::new(
+					SyncWorley::default()
+						.set_frequency(0.05)
+						.set_seed(seeds.worley().heights()),
+				)
+				.set_scale(0.1),
+				base(),
+			),
+			strength_noise.clone().set_seed(seeds.worley().strength()),
+			// Constant::new(-1.0),
+		);
+
+		let billow = Source::new(
+			Add::new(
+				ScaleBias::new(
+					Billow::<Perlin>::default()
+						.set_frequency(0.02)
+						.set_octaves(2)
+						.set_seed(seeds.billow().heights()),
+				)
+				.set_scale(0.04),
+				base(),
+			),
+			strength_noise.clone().set_seed(seeds.billow().strength()),
+			// Constant::new(-1.0),
+		);
+
+		let ridged = Source::new(
+			Add::new(
+				ScaleBias::new(
+					RidgedMulti::<Perlin>::default()
+						.set_frequency(0.02)
+						.set_seed(seeds.ridged().heights()),
+				)
+				.set_scale(0.07),
+				base(),
+			),
+			strength_noise.clone().set_seed(seeds.ridged().strength()),
+			// Constant::new(-1.0),
+		);
+
+		let noise = ChooseAndSmooth::new([perlin, worley, billow, ridged]);
+		Self::new(noise)
+	}
 }
 
 #[derive(Resource, Default, Deref, DerefMut)]
@@ -459,3 +472,170 @@ pub fn unload_distant_chunks(
 
 #[derive(Resource, Deref, DerefMut, Debug, Reflect)]
 pub struct UnloadDistance(f32);
+
+mod seeds {
+	use crate::planet::{seeds::PlanetSeed, terrain};
+	use bevy::utils::RandomState;
+	use std::hash::{BuildHasher, Hasher};
+
+	#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+	#[repr(C)]
+	pub struct TerrainSeeds {
+		base: u64,
+		perlin: HSSeed,
+		worley: HSSeed,
+		billow: HSSeed,
+		ridged: HSSeed,
+	}
+
+	impl From<&PlanetSeed> for TerrainSeeds {
+		fn from(value: &PlanetSeed) -> Self {
+			let value = value.hash();
+
+			// Randomly generated during development.
+			// WARNING: Changing these will break compatibility with older seeds.
+			let mut hasher = RandomState::with_seeds(
+				14290938944643142730,
+				324773583170826462,
+				5391126888610969733,
+				8770814408611468823,
+			)
+			.build_hasher();
+
+			hasher.write(value);
+			let base = hasher.finish();
+			hasher.write(value);
+			let perlin = bytemuck::cast::<_, [u32; 2]>(hasher.finish());
+			hasher.write(value);
+			let mut worley = bytemuck::cast::<_, [u32; 2]>(hasher.finish());
+			for _ in 0..1024 {
+				// Best effort at avoiding strength collisions.
+				if perlin[1] == worley[1] {
+					hasher.write(value);
+					worley = bytemuck::cast(hasher.finish());
+				} else {
+					break;
+				}
+			}
+
+			hasher.write(value);
+			let mut billow = bytemuck::cast::<_, [u32; 2]>(hasher.finish());
+			for _ in 0..1024 {
+				// Best effort at avoiding strength collisions.
+				if [perlin[1], worley[1]].contains(&billow[1]) {
+					hasher.write(value);
+					billow = bytemuck::cast(hasher.finish());
+				} else {
+					break;
+				}
+			}
+
+			hasher.write(value);
+			let mut ridged = bytemuck::cast::<_, [u32; 2]>(hasher.finish());
+			for _ in 0..1024 {
+				// Best effort at avoiding strength collisions.
+				if [perlin[1], worley[1], billow[1]].contains(&ridged[1]) {
+					hasher.write(value);
+					ridged = bytemuck::cast(hasher.finish());
+				} else {
+					break;
+				}
+			}
+
+			Self {
+				base,
+				perlin: HSSeed::new(perlin[0], perlin[1]),
+				worley: HSSeed::new(worley[0], worley[1]),
+				billow: HSSeed::new(billow[0], billow[1]),
+				ridged: HSSeed::new(ridged[0], ridged[1]),
+			}
+		}
+	}
+
+	impl TerrainSeeds {
+		pub fn base(&self) -> u64 {
+			self.base
+		}
+
+		pub fn perlin(&self) -> HSSeed {
+			self.perlin
+		}
+		pub fn worley(&self) -> HSSeed {
+			self.worley
+		}
+		pub fn billow(&self) -> HSSeed {
+			self.billow
+		}
+		pub fn ridged(&self) -> HSSeed {
+			self.ridged
+		}
+	}
+
+	/// Combined heights and strength seed for [ChooseAndSmooth](terrain::noise::ChooseAndSmooth)
+	#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+	#[repr(C)]
+	pub struct HSSeed {
+		heights: u32,
+		strength: u32,
+	}
+
+	impl HSSeed {
+		fn new(heights: u32, strength: u32) -> Self {
+			Self { heights, strength }
+		}
+
+		pub fn heights(&self) -> u32 {
+			self.heights
+		}
+		pub fn strength(&self) -> u32 {
+			self.strength
+		}
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use crate::planet::{
+			seeds::PlanetSeed,
+			terrain::seeds::{HSSeed, TerrainSeeds},
+		};
+
+		#[test]
+		fn seed_equivalence() {
+			let seed = rand::random::<PlanetSeed>();
+			let a = TerrainSeeds::from(&seed);
+			let b = TerrainSeeds::from(&seed);
+			assert_eq!(a, b);
+		}
+
+		#[test]
+		fn version_equivalence() {
+			// Note: If sources are added or removed, the sources from the previous version should remain equivalent,
+			// but it is fine to add the values for the new sources or remove old ones here.
+			let seed = PlanetSeed::from(
+				"This is a PlanetSeed for testing TerrainSeed equivalence across versions.",
+			);
+			assert_eq!(
+				TerrainSeeds::from(&seed),
+				TerrainSeeds {
+					base: 7920230168977959780,
+					perlin: HSSeed {
+						heights: 2685576922,
+						strength: 1151182273
+					},
+					worley: HSSeed {
+						heights: 895711232,
+						strength: 484265962
+					},
+					billow: HSSeed {
+						heights: 3037546005,
+						strength: 57840775
+					},
+					ridged: HSSeed {
+						heights: 401089611,
+						strength: 2179398915
+					}
+				},
+			);
+		}
+	}
+}

--- a/rs/src/planet/terrain.rs
+++ b/rs/src/planet/terrain.rs
@@ -1,6 +1,6 @@
 use crate::{
 	mats::{DistanceDither, StdMatExt},
-	nav::heightmap::FnsThatShouldBePub,
+	nav::heightmap::{FnsThatShouldBePub, TriId},
 	offloading::{wasm_yield, Offload, OffloadedTask, TaskHandle, TaskOffloader},
 	planet::{
 		chunks::{
@@ -31,7 +31,12 @@ use bevy::{
 	},
 	utils::HashMap,
 };
-use bevy_rapier3d::{parry::shape::SharedShape, prelude::*};
+use bevy_rapier3d::{
+	geometry::shape_views::HeightFieldCellStatus,
+	na::Point3,
+	parry::shape::{SharedShape, Triangle},
+	prelude::*,
+};
 use enum_components::ERef;
 use rapier3d::{geometry::HeightField, na::DMatrix};
 use std::{f32::consts::*, ops::DerefMut, sync::Arc};
@@ -230,6 +235,91 @@ impl Default for TerrainObject {
 #[derive(Component, Debug, Clone)]
 pub struct Ground {
 	pub heights: Arc<HeightField>,
+}
+
+impl Ground {
+	pub fn new(heights: impl Into<Arc<HeightField>>) -> Self {
+		Self {
+			heights: heights.into(),
+		}
+	}
+
+	pub fn tri_at(&self, local_point: Vec2) -> Option<(TriId, Triangle)> {
+		// HeightField has to be inverted for chunk indices to follow PlanetVec2
+		let rel = Vec2::new(local_point.x, -local_point.y);
+		let point = Point3::new(rel.x, 0.0, rel.y);
+		let (i, j) = self.heights.cell_at_point(&point)?;
+		let (left, right) = self.heights.triangles_at(i, j);
+
+		// ZIG-ZAG
+		// a -- c  c
+		// | L / / |
+		// |  / /  |
+		// | / / R |
+		// b  a -- b
+		//
+		// NORMAL
+		// a  a -- c
+		// | \ \ R |
+		// |  \ \  |
+		// | L \ \ |
+		// b -- c  b
+		//
+		let tri = match (left, right) {
+			(Some(left), Some(right)) => {
+				let status = self.heights.cell_status(i, j);
+				let (l, r) = if status.contains(HeightFieldCellStatus::ZIGZAG_SUBDIVISION) {
+					debug_assert!(
+						{
+							let p = left.a - right.a;
+							p.x * p.x + p.y * p.y + p.z * p.z
+						} <= f32::EPSILON
+					);
+					(left.a.xy(), right.b.xy())
+				} else {
+					debug_assert!(
+						{
+							let p = left.c - right.c;
+							p.x * p.x + p.y * p.y + p.z * p.z
+						} <= f32::EPSILON
+					);
+					(left.b.xy(), right.c.xy())
+				};
+				// Checking the squared distances to the opposing points is at least as cheap as any other solution.
+				let p = point.xy();
+				let dl = l - p.xy();
+				let dr = r - p.xy();
+				let dl = dl.x * dl.x + dl.y * dl.y;
+				let dr = dr.x * dr.x + dr.y * dr.y;
+				if dl < dr {
+					(self.heights.triangle_id(i, j, true), left)
+				} else {
+					(self.heights.triangle_id(i, j, false), right)
+				}
+			}
+			(Some(left), None) => (self.heights.triangle_id(i, j, true), left),
+			(None, Some(right)) => (self.heights.triangle_id(i, j, false), right),
+			(None, None) => return None,
+		};
+		Some(tri)
+	}
+
+	pub fn height_at(&self, local_point: Vec2) -> Option<f32> {
+		self.tri_and_height_at(local_point)
+			.map(|(_, height)| height)
+	}
+
+	pub fn tri_and_height_at(&self, local_point: Vec2) -> Option<(TriId, f32)> {
+		// HeightField has to be inverted for chunk indices to follow PlanetVec2
+		let rel = Vec2::new(local_point.x, -local_point.y);
+		let (id, tri) = self.tri_at(local_point)?;
+		let da = TERRAIN_CELL_SIZE - (Vec2::from(tri.a.xz()) - rel).length();
+		let db = TERRAIN_CELL_SIZE - (Vec2::from(tri.b.xz()) - rel).length();
+		let dc = TERRAIN_CELL_SIZE - (Vec2::from(tri.c.xz()) - rel).length();
+		let sum = da + db + dc;
+		let height = (da / sum) * tri.a.y + (db / sum) * tri.b.y + (dc / sum) * tri.c.y;
+		Some((id, height))
+	}
 }
 
 #[derive(Resource, Deref, Clone)]

--- a/rs/src/planet/terrain/noise.rs
+++ b/rs/src/planet/terrain/noise.rs
@@ -67,6 +67,7 @@ impl<const N: usize> ChooseAndSmooth<N> {
 			for y in 0..rows {
 				let point = [
 					center.x + (x as f64 * stretch.x) - (columns as f64 * 0.5),
+					// HeightField has to be inverted for chunk indices to follow PlanetVec2
 					center.y + (-(y as f64) * stretch.y) + (rows as f64 * 0.5),
 				];
 				let mut value_caches = [None; N];

--- a/rs/src/player.rs
+++ b/rs/src/player.rs
@@ -206,7 +206,7 @@ pub fn setup(
 		crosshair_mat,
 	});
 
-	spawn_events.send(PlayerSpawnEvent { id });
+	spawn_events.send(PlayerSpawnEvent { id, died_at: PlanetVec2::default() });
 }
 
 #[derive(Resource, Clone, Debug)]
@@ -245,6 +245,10 @@ use crate::{
 	util::{Diff, Prev, TransformDelta},
 };
 use player_entity::*;
+use crate::planet::chunks::{ChunkCenter, LoadedChunks};
+use crate::planet::frame::Frame;
+use crate::planet::PlanetVec2;
+use crate::planet::terrain::Ground;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum PlayerArm {
@@ -278,8 +282,18 @@ pub fn spawn_players(
 	params: Res<PlayerParams>,
 	mut events: ResMut<Events<PlayerSpawnEvent>>,
 	mut pkv: ResMut<PkvStore>,
+	loaded_chunks: Res<LoadedChunks>,
+	grounds: Query<(&ChunkCenter, &Ground)>,
+	frame: Res<Frame>,
 ) {
+	let mut to_retry = vec![];
 	for event in events.drain() {
+		let spawn_point = frame.planet_coords_of(Vec2::ZERO);
+		let Some(z) = loaded_chunks.height_at(spawn_point, &grounds) else {
+			to_retry.push(event);
+			continue
+		};
+		
 		let PlayerSpawnData {
 			ship_scene,
 			antigrav_pulse_mesh,
@@ -339,7 +353,7 @@ pub fn spawn_players(
 				}),
 				KinematicPositionBased,
 				TransformBundle::from_transform(Transform {
-					translation: Vec3::Z * 4096.0,
+					translation: Vec3::new(0.0, 0.0, z + 2048.0),
 					..default()
 				}),
 				Velocity::default(),
@@ -380,6 +394,9 @@ pub fn spawn_players(
 			(crosshair_mesh, crosshair_mat),
 			prefs,
 		);
+	}
+	for event in to_retry.drain(..) {
+		events.send(event);
 	}
 }
 
@@ -724,9 +741,11 @@ fn player_arms(
 pub fn reset_oob(
 	mut cmds: Commands,
 	q: Query<(&GlobalTransform, &BelongsToPlayer)>,
+	roots: Query<(&GlobalTransform, &BelongsToPlayer), ERef<Root>>,
 	player_nodes: Query<(Entity, &BelongsToPlayer), (Without<NeverDespawn>, Without<Parent>)>,
 	bounds: Res<PlayerBounds>,
 	mut respawn_timers: ResMut<PlayerRespawnTimers>,
+	frame: Res<Frame>,
 ) {
 	let mut to_respawn = HashSet::new();
 	for (xform, owner) in &q {
@@ -741,7 +760,9 @@ pub fn reset_oob(
 	for (id, owner) in &player_nodes {
 		if to_respawn.remove(&owner) {
 			cmds.entity(id).despawn_recursive();
-			respawn_timers.start(**owner, Duration::from_secs(3)).ok();
+			roots.iter().find_map(|(global, id)| (*id == *owner).then(||
+				respawn_timers.start(**id, frame.planet_coords_of(global.translation().xy()), Duration::from_secs(3)).ok()
+			));
 		}
 	}
 }
@@ -806,6 +827,7 @@ pub fn orbs_follow_arms(
 #[derive(Event, Clone, Debug)]
 pub struct PlayerSpawnEvent {
 	id: PlayerId,
+	died_at: PlanetVec2,
 }
 
 pub fn countdown_respawn(
@@ -813,10 +835,10 @@ pub fn countdown_respawn(
 	mut timers: ResMut<PlayerRespawnTimers>,
 	t: Res<Time>,
 ) {
-	for (&id, timer) in timers.iter_mut() {
+	for (&id, (died_at, timer)) in timers.iter_mut() {
 		timer.tick(t.delta());
 		if timer.just_finished() {
-			spawn_events.send(PlayerSpawnEvent { id });
+			spawn_events.send(PlayerSpawnEvent { id, died_at: *died_at });
 		}
 	}
 }
@@ -824,13 +846,17 @@ pub fn countdown_respawn(
 pub fn kill_on_key(
 	mut cmds: Commands,
 	q: Query<(Entity, &BelongsToPlayer), (Without<NeverDespawn>, Without<Parent>)>,
+	roots: Query<(&GlobalTransform, &BelongsToPlayer), ERef<Root>>,
 	input: Res<Input<KeyCode>>,
 	mut respawn_timers: ResMut<PlayerRespawnTimers>,
+	frame: Res<Frame>,
 ) {
 	if input.just_pressed(KeyCode::K) {
 		for (id, owner) in &q {
 			cmds.entity(id).despawn_recursive();
-			respawn_timers.start(**owner, Duration::from_secs(2)).ok();
+			roots.iter().find_map(|(global, id)| (*id == *owner).then(||
+				respawn_timers.start(**id, frame.planet_coords_of(global.translation().xy()), Duration::from_secs(2)).ok()
+			));
 		}
 	}
 }
@@ -840,7 +866,7 @@ pub fn play_death_sound(
 	audio: Res<Audio>,
 	respawn_timers: Res<PlayerRespawnTimers>,
 ) {
-	for timer in respawn_timers.values() {
+	for (_, timer) in respawn_timers.values() {
 		if timer.elapsed() == Duration::ZERO {
 			audio.play(sound.0.clone()).with_volume(0.4);
 		}
@@ -848,14 +874,14 @@ pub fn play_death_sound(
 }
 
 #[derive(Resource, Debug, Default, Deref, DerefMut)]
-pub struct PlayerRespawnTimers(HashMap<PlayerId, Timer>);
+pub struct PlayerRespawnTimers(HashMap<PlayerId, (PlanetVec2, Timer)>);
 
 impl PlayerRespawnTimers {
-	pub fn start(&mut self, player: PlayerId, duration: Duration) -> Result<(), Duration> {
-		let timer = self
+	pub fn start(&mut self, player: PlayerId, death_point: PlanetVec2, duration: Duration) -> Result<(), Duration> {
+		let (_, timer) = self
 			.0
 			.entry(player)
-			.or_insert_with(|| Timer::new(duration, TimerMode::Once));
+			.or_insert_with(|| (death_point, Timer::new(duration, TimerMode::Once)));
 		if timer.finished() {
 			timer.set_duration(duration);
 			timer.reset();

--- a/rs/src/player.rs
+++ b/rs/src/player.rs
@@ -245,10 +245,9 @@ use crate::{
 	util::{Diff, Prev, TransformDelta},
 };
 use player_entity::*;
-use crate::planet::chunks::{ChunkCenter, LoadedChunks};
+use crate::planet::chunks::ChunkFinder;
 use crate::planet::frame::Frame;
 use crate::planet::PlanetVec2;
-use crate::planet::terrain::Ground;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum PlayerArm {
@@ -282,14 +281,13 @@ pub fn spawn_players(
 	params: Res<PlayerParams>,
 	mut events: ResMut<Events<PlayerSpawnEvent>>,
 	mut pkv: ResMut<PkvStore>,
-	loaded_chunks: Res<LoadedChunks>,
-	grounds: Query<(&ChunkCenter, &Ground)>,
+	chunks: ChunkFinder,
 	frame: Res<Frame>,
 ) {
 	let mut to_retry = vec![];
 	for event in events.drain() {
 		let spawn_point = frame.planet_coords_of(Vec2::ZERO);
-		let Some(z) = loaded_chunks.height_at(spawn_point, &grounds) else {
+		let Some(z) = chunks.height_at(spawn_point) else {
 			to_retry.push(event);
 			continue
 		};

--- a/rs/src/player/camera.rs
+++ b/rs/src/player/camera.rs
@@ -31,7 +31,7 @@ use bevy_rapier3d::{
 use enum_components::{ERef, EntityEnumCommands};
 use std::f32::consts::FRAC_PI_2;
 
-const CAM_SMOOTHING: f32 = 0.33;
+const CAM_SMOOTHING: f32 = 0.25;
 const MAX_CAM_DIST: f32 = 32.0;
 const MIN_CAM_DIST: f32 = 9.6;
 

--- a/rs/src/player/camera.rs
+++ b/rs/src/player/camera.rs
@@ -110,7 +110,8 @@ pub fn spawn_camera<'w, 's, 'a>(
 
 	let mut cmds = cmds.spawn((
 		BelongsToPlayer::with_id(player_id),
-		TransformBundle::default(),
+		// Start the camera above the player in the fog, then zoom down
+		TransformBundle::from_transform(Transform::from_translation(Vec3::Z * 4096.0)),
 		Collider::ball(2.0),
 		CollisionGroups::new(Group::empty(), Group::empty()),
 		CamTarget::default(),
@@ -166,7 +167,7 @@ pub fn spawn_pivot<'w, 's, 'a>(
 	let mut cmds = cmds
 		.spawn((
 			owner,
-			CameraVertSlider::default(),
+			CameraVertSlider(0.125),
 			TransformBundle::from_transform(Transform {
 				translation: Vect::new(0.0, 0.0, MIN_CAM_DIST),
 				..default()

--- a/rs/src/player/camera.rs
+++ b/rs/src/player/camera.rs
@@ -4,9 +4,7 @@ use super::{
 };
 use crate::{planet::sky::SkyShader, player::PlayerId, settings::Settings, NeverDespawn};
 
-use crate::{
-	anim::ComponentDelta, player::prefs::CamSmoothing, util::LerpSlerp,
-};
+use crate::{anim::ComponentDelta, player::prefs::CamSmoothing, util::LerpSlerp};
 use bevy::{
 	core_pipeline::{
 		bloom::BloomSettings, clear_color::ClearColorConfig, fxaa::Fxaa, tonemapping::Tonemapping,

--- a/rs/src/ui/game_ui.rs
+++ b/rs/src/ui/game_ui.rs
@@ -1,12 +1,7 @@
-use bevy::{
-	app::{App, Update},
-	prelude::{Commands, VisibilityBundle},
-};
+use bevy::prelude::*;
 
 pub fn plugin(app: &mut App) -> &mut App {
 	app.add_systems(Update, setup)
 }
 
-pub fn setup(mut cmds: Commands) {
-	cmds.spawn((VisibilityBundle::default(),));
-}
+pub fn setup(mut cmds: Commands) {}


### PR DESCRIPTION
Makes it easier to get the height of the terrain at a specific point, as well as the triangle at that point, chunk ID, etc.

Closes #16. Picking random nav graph nodes will have to come later, and will probably be based more on this functionality than the navigation graph iterators anyway. It is likely way faster to try to get a triangle at a certain point, retrying if it's invalid for the given entity, rather than iterate through thousands of nodes, filtering each one, to pick one randomly.