### PR TITLE
Update to Bevy 0.16

### DIFF
--- a/justfile
+++ b/justfile
@@ -45,6 +45,11 @@ fix:
 
 # ── Test ──────────────────────────────────────────────────────────────────────
 
+# Compile-check the desktop debug run feature set used by `just run`
+check-run-debug:
+    cargo check --profile desktop --package sond-has --bin sond-has \
+        --features=bevy/file_watcher,bevy/asset_processor,debugging,dev_ui,dylib
+
 # Run engine tests
 test-engine:
     cargo test --package sond-has-engine --no-default-features --features=testing
@@ -58,7 +63,7 @@ test-rng:
     cargo test --package sond-has-rng
 
 # Run all unit tests
-test-all: test-engine test-game test-rng
+test-all: check-run-debug test-engine test-game test-rng
 
 # Run visual tests (opens a window)
 vis-test:

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -20,15 +20,19 @@ checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
 name = "accesskit"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d3b8f9bae46a948369bc4a03e815d4ed6d616bd00de4051133a5019dc31c5a"
+checksum = "becf0eb5215b6ecb0a739c31c21bd83c4f326524c9b46b7e882d77559b60a529"
+dependencies = [
+ "enumn",
+ "serde",
+]
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47983a1084940ba9a39c077a8c63e55c619388be5476ac04c804cfbd1e63459"
+checksum = "d0bf66a7bf0b7ea4fd7742d50b64782a88f99217cf246b3f93b4162528dde520"
 dependencies = [
  "accesskit",
  "hashbrown 0.15.2",
@@ -37,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_macos"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7329821f3bd1101e03a7d2e03bd339e3ac0dc64c70b4c9f9ae1949e3ba8dece1"
+checksum = "09e230718177753b4e4ad9e1d9f6cfc2f4921212d4c1c480b253f526babb258d"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -51,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fcd5d23d70670992b823e735e859374d694a3d12bfd8dd32bd3bd8bedb5d81"
+checksum = "65178f3df98a51e4238e584fcb255cb1a4f9111820848eeddd37663be40a625f"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -66,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_winit"
-version = "0.23.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6a48dad5530b6deb9fc7a52cc6c3bf72cdd9eb8157ac9d32d69f2427a5e879"
+checksum = "34d941bb8c414caba6e206de669c7dc0dbeb305640ea890772ee422a40e6b89f"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -84,17 +88,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "const-random",
- "getrandom",
+ "getrandom 0.2.12",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.32",
 ]
 
 [[package]]
@@ -104,6 +113,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
 ]
 
 [[package]]
@@ -119,7 +137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37fe60779335388a88c01ac6c3be40304d1e349de3ada3b15f7808bb90fa9dce"
 dependencies = [
  "alsa-sys",
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "libc",
 ]
 
@@ -140,7 +158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
 dependencies = [
  "android-properties",
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "cc",
  "cesu8",
  "jni",
@@ -191,6 +209,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "array-init"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,9 +239,9 @@ checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "as-raw-xcb-connection"
@@ -236,12 +271,14 @@ dependencies = [
 
 [[package]]
 name = "async-broadcast"
-version = "0.5.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener 2.5.3",
+ "event-listener 5.2.0",
+ "event-listener-strategy 0.5.3",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -296,18 +333,18 @@ name = "async-task"
 version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
-
-[[package]]
-name = "atomic-arena"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5450eca8ce5abcfd5520727e975ebab30ccca96030550406b0ca718b224ead10"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "atomicow"
@@ -320,6 +357,29 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "base64"
@@ -341,31 +401,29 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bevy"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eaad7fe854258047680c51c3cacb804468553c04241912f6254c841c67c0198"
+checksum = "4b8369c16b7c017437021341521f8b4a0d98e1c70113fb358c3258ae7d661d79"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
 name = "bevy-inspector-egui"
-version = "0.29.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d3ea87310d78bacc94471bcf5a8b63ead43e7263d404571832c2297458b856"
+checksum = "4971e763f289921fd4616418628458bec26a6fc13fe4299c0e4066f39d7ceaa2"
 dependencies = [
  "bevy-inspector-egui-derive",
  "bevy_app",
  "bevy_asset",
  "bevy_color",
- "bevy_core",
- "bevy_core_pipeline",
  "bevy_ecs",
  "bevy_egui",
- "bevy_hierarchy",
  "bevy_log",
  "bevy_math",
  "bevy_pbr",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_state",
@@ -384,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "bevy-inspector-egui-derive"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7259e525c7844b23f10fd2b2efaa3eea57996f101cc30e833070d139e2b4e4d"
+checksum = "2656316165dbe2af6b3acaa763332f5dbdd12f809d59f5bf4304e0642a8005c9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -395,32 +453,33 @@ dependencies = [
 
 [[package]]
 name = "bevy_a11y"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245a938f754f70a380687b89f1c4dac75b62d58fae90ae969fcfb8ecd91ed879"
+checksum = "ed3561712cf49074d89e9989bfc2e6c6add5d33288f689db9a0c333300d2d004"
 dependencies = [
  "accesskit",
  "bevy_app",
  "bevy_derive",
  "bevy_ecs",
  "bevy_reflect",
+ "serde",
 ]
 
 [[package]]
 name = "bevy_animation"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e2b3e4e6cb4df085b941b105f2c790901e34c8571e02342f8e96acdf7cf7d1"
+checksum = "49796627726d0b9a722ad9a0127719e7c1868f474d6575ec0f411e8299c4d7bb"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_color",
- "bevy_core",
  "bevy_derive",
  "bevy_ecs",
- "bevy_hierarchy",
  "bevy_log",
  "bevy_math",
+ "bevy_mesh",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_time",
@@ -428,40 +487,46 @@ dependencies = [
  "bevy_utils",
  "blake3",
  "derive_more",
- "downcast-rs",
+ "downcast-rs 2.0.2",
  "either",
  "petgraph",
  "ron",
  "serde",
  "smallvec",
+ "thiserror 2.0.11",
  "thread_local",
+ "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "bevy_app"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ac033a388b8699d241499a43783a09e6a3bab2430f1297c6bd4974095efb3f"
+checksum = "4491cc4c718ae76b4c6883df58b94cc88b32dcd894ea8d5b603c7c7da72ca967"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
+ "cfg-if",
  "console_error_panic_hook",
  "ctrlc",
- "derive_more",
- "downcast-rs",
+ "downcast-rs 2.0.2",
+ "log",
+ "thiserror 2.0.11",
+ "variadics_please",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "bevy_asset"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fd901b3be016088c4dda2f628bda96b7cb578b9bc8ae684bbf30bec0a9483e"
+checksum = "f56111d9b88d8649f331a667d9d72163fb26bd09518ca16476d238653823db1e"
 dependencies = [
  "async-broadcast",
  "async-fs",
@@ -470,16 +535,17 @@ dependencies = [
  "bevy_app",
  "bevy_asset_macros",
  "bevy_ecs",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
  "bevy_window",
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "blake3",
  "crossbeam-channel",
  "derive_more",
  "disqualified",
- "downcast-rs",
+ "downcast-rs 2.0.2",
  "either",
  "futures-io",
  "futures-lite",
@@ -488,6 +554,8 @@ dependencies = [
  "ron",
  "serde",
  "stackfuture",
+ "thiserror 2.0.11",
+ "tracing",
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -496,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset_macros"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6725a785789ece8d8c73bba25fdac5e50494d959530e89565bbcea9f808b7181"
+checksum = "a4cca3e67c0ec760d8889d42293d987ce5da92eaf9c592bf5d503728a63b276d"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -508,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_color"
-version = "0.15.4"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87b7137ffa9844ae542043769fb98c35efbf2f8a8429ff2a73d8ef30e58baaa"
+checksum = "5c101cbe1e26b8d701eb77263b14346e2e0cbbd2a6e254b9b1aead814e5ca8d3"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -518,56 +586,45 @@ dependencies = [
  "derive_more",
  "encase",
  "serde",
+ "thiserror 2.0.11",
  "wgpu-types",
 ]
 
 [[package]]
-name = "bevy_core"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9ce8da8e4016f63c1d361b52e61aaf4348c569829c74f1a5bbedfd8d3d57a3"
-dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_reflect",
- "bevy_tasks",
- "bevy_utils",
- "serde",
- "uuid",
-]
-
-[[package]]
 name = "bevy_core_pipeline"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee0ff0f4723f30a5a6578915dbfe0129f2befaec8438dde70ac1fb363aee01f5"
+checksum = "59ed46363cad80dc00f08254c3015232bd6f640738403961c6d63e7ecfc61625"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_color",
- "bevy_core",
  "bevy_derive",
+ "bevy_diagnostic",
  "bevy_ecs",
  "bevy_image",
  "bevy_math",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
- "bitflags 2.6.0",
- "derive_more",
+ "bitflags 2.11.1",
+ "bytemuck",
  "nonmax",
  "radsort",
  "serde",
  "smallvec",
+ "thiserror 2.0.11",
+ "tracing",
 ]
 
 [[package]]
 name = "bevy_derive"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d94761ce947b0a2402fd949fe1e7a5b1535293130ba4cd9893be6295d4680a"
+checksum = "1b837bf6c51806b10ebfa9edf1844ad80a3a0760d6c5fac4e90761df91a8901a"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -576,56 +633,63 @@ dependencies = [
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e83c65979f063b593917ab9b1d7328c5854dba4b6ddf1ab78156c0105831fdf"
+checksum = "48797366f312a8f31e237d08ce3ee70162591282d2bfe7c5ad8be196fb263e55"
 dependencies = [
  "bevy_app",
- "bevy_core",
  "bevy_ecs",
+ "bevy_platform",
  "bevy_tasks",
  "bevy_time",
  "bevy_utils",
  "const-fnv1a-hash",
+ "log",
+ "serde",
 ]
 
 [[package]]
 name = "bevy_dylib"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b2a0773cfe9d27256fba1e5005a14968b34f751c09397ee4e278f0fb235db"
+checksum = "1dc3602098b2604941b2829a04ac316de1e36aad949cbffce8861896b9b32532"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
 name = "bevy_ecs"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1597106cc01e62e6217ccb662e0748b2ce330893f27c7dc17bac33e0bb99bca9"
+checksum = "3c2bf6521aae57a0ec3487c4bfb59e36c4a378e834b626a4bea6a885af2fdfe7"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
+ "bevy_platform",
  "bevy_ptr",
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
+ "bumpalo",
  "concurrent-queue",
  "derive_more",
  "disqualified",
- "fixedbitset 0.5.7",
+ "fixedbitset",
+ "indexmap",
+ "log",
  "nonmax",
- "petgraph",
  "serde",
  "smallvec",
+ "thiserror 2.0.11",
+ "variadics_please",
 ]
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f453adf07712b39826bc5845e5b0887ce03204ee8359bbe6b40a9afda60564a1"
+checksum = "38748d6f3339175c582d751f410fb60a93baf2286c3deb7efebb0878dce7f413"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -635,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_egui"
-version = "0.32.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a4b8df063d7c4d4171bc853e5ea0d67c7f1b5edd3b014d43acbfe3042dd6cf4"
+checksum = "3a3d58a8afdb6100bca50251043a85320391742cae125d559f6cca3a16b84cdd"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -647,17 +711,17 @@ dependencies = [
  "bevy_input",
  "bevy_log",
  "bevy_math",
- "bevy_picking",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_time",
- "bevy_utils",
  "bevy_window",
  "bevy_winit",
  "bytemuck",
  "crossbeam-channel",
  "egui",
  "encase",
+ "image",
  "js-sys",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -669,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_encase_derive"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37ad69d36bb9e8479a88d481ef9748f5d7ab676040531d751d3a44441dcede7"
+checksum = "8148f4edee470a2ea5cad010184c492a4c94c36d7a7158ea28e134ea87f274ab"
 dependencies = [
  "bevy_macro_utils",
  "encase_derive_impl",
@@ -679,24 +743,26 @@ dependencies = [
 
 [[package]]
 name = "bevy_gilrs"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a737451ccd6be5da68fbba5d984328b8a82eebd16c1fda0bec840090a3d454fd"
+checksum = "97efef87c631949e67d06bb5d7dfd2a5f936b3b379afb6b1485b08edbb219b87"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bevy_input",
+ "bevy_platform",
  "bevy_time",
  "bevy_utils",
- "derive_more",
  "gilrs",
+ "thiserror 2.0.11",
+ "tracing",
 ]
 
 [[package]]
 name = "bevy_gizmos"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1614516d0922ad60e87cc39658422286ed684aaf4b3162d25051bc105eed814"
+checksum = "7823154a9682128c261d8bddb3a4d7192a188490075c527af04520c2f0f8aad6"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -714,13 +780,14 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bytemuck",
+ "tracing",
 ]
 
 [[package]]
 name = "bevy_gizmos_macros"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0edb9e0dca64e0fc9d6b1d9e6e2178396e339e3e2b9f751e2504e3ea4ddf4508"
+checksum = "f378f3b513218ddc78254bbe76536d9de59c1429ebd0c14f5d8f2a25812131ad"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -730,102 +797,113 @@ dependencies = [
 
 [[package]]
 name = "bevy_gltf"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8364f34bc08fe067ce32418e22ee96e177101dbf1bc00803aaeb2b262615be"
+checksum = "10a080237c0b8842ccc15a06d3379302c68580eeea4497b1c7387e470eda1f07"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
  "bevy_app",
  "bevy_asset",
  "bevy_color",
- "bevy_core",
  "bevy_core_pipeline",
  "bevy_ecs",
- "bevy_hierarchy",
  "bevy_image",
  "bevy_math",
+ "bevy_mesh",
  "bevy_pbr",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_scene",
  "bevy_tasks",
  "bevy_transform",
  "bevy_utils",
- "derive_more",
+ "fixedbitset",
  "gltf",
+ "itertools 0.14.0",
  "percent-encoding",
  "serde",
  "serde_json",
  "smallvec",
-]
-
-[[package]]
-name = "bevy_hierarchy"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ced04e04437d0a439fe4722544c2a4678c1fe3412b57ee489d817c11884045"
-dependencies = [
- "bevy_app",
- "bevy_core",
- "bevy_ecs",
- "bevy_reflect",
- "bevy_utils",
- "disqualified",
- "smallvec",
+ "thiserror 2.0.11",
+ "tracing",
 ]
 
 [[package]]
 name = "bevy_image"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b384d1ce9c87f6151292a76233897a628c2a50b3560487c4d74472225d49826"
+checksum = "65e6e900cfecadbc3149953169e36b9e26f922ed8b002d62339d8a9dc6129328"
 dependencies = [
+ "bevy_app",
  "bevy_asset",
  "bevy_color",
  "bevy_math",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_utils",
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "bytemuck",
- "derive_more",
  "futures-lite",
+ "guillotiere",
+ "half",
  "image",
  "ktx2",
+ "rectangle-pack",
  "ruzstd",
  "serde",
- "wgpu",
+ "thiserror 2.0.11",
+ "tracing",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_input"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52589939ca09695c69d629d166c5edf1759feaaf8f2078904aae9c33d08f5c3"
+checksum = "18d6b6516433f6f7d680f648d04eb1866bb3927a1782d52f74831b62042f3cd1"
 dependencies = [
  "bevy_app",
- "bevy_core",
  "bevy_ecs",
  "bevy_math",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_utils",
  "derive_more",
+ "log",
  "serde",
  "smol_str",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "bevy_input_focus"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e2d079fda74d1416e0a57dac29ea2b79ff77f420cd6b87f833d3aa29a46bc4d"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_input",
+ "bevy_math",
+ "bevy_reflect",
+ "bevy_window",
+ "log",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "bevy_internal"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e0c1d980d276e11558184d0627c8967ad8b70dab3e54a0f377bb53b98515b6"
+checksum = "857da8785678fde537d02944cd20dec9cafb7d4c447efe15f898dc60e733cacd"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
  "bevy_app",
  "bevy_asset",
  "bevy_color",
- "bevy_core",
  "bevy_core_pipeline",
  "bevy_derive",
  "bevy_diagnostic",
@@ -833,13 +911,14 @@ dependencies = [
  "bevy_gilrs",
  "bevy_gizmos",
  "bevy_gltf",
- "bevy_hierarchy",
  "bevy_image",
  "bevy_input",
+ "bevy_input_focus",
  "bevy_log",
  "bevy_math",
  "bevy_pbr",
  "bevy_picking",
+ "bevy_platform",
  "bevy_ptr",
  "bevy_reflect",
  "bevy_render",
@@ -858,28 +937,30 @@ dependencies = [
 
 [[package]]
 name = "bevy_kira_audio"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5ccfdf82791bcda06527cf752aa5ceffb20b5a13af93dd4e2f1105bafb4c2e"
+checksum = "af5b8f1d4da8430903286ee3b9c4b95fb10ca54b0f7b90b94f106e7c1dde8e0b"
 dependencies = [
  "anyhow",
  "bevy",
+ "bevy_math",
  "kira",
  "parking_lot",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "uuid",
 ]
 
 [[package]]
 name = "bevy_log"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b381a22e01f24af51536ef1eace94298dd555d06ffcf368125d16317f5f179cb"
+checksum = "d7a61ee8aef17a974f5ca481dcedf0c2bd52670e231d4c4bc9ddef58328865f9"
 dependencies = [
  "android_log-sys",
  "bevy_app",
  "bevy_ecs",
  "bevy_utils",
+ "tracing",
  "tracing-log",
  "tracing-oslog",
  "tracing-subscriber",
@@ -888,10 +969,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb6ded1ddc124ea214f6a2140e47a78d1fe79b0638dad39419cdeef2e1133f1"
+checksum = "052eeebcb8e7e072beea5031b227d9a290f8a7fbbb947573ab6ec81df0fb94be"
 dependencies = [
+ "parking_lot",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -900,25 +982,29 @@ dependencies = [
 
 [[package]]
 name = "bevy_math"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c2650169161b64f9a93e41f13253701fdf971dc95265ed667d17bea6d2a334f"
+checksum = "68553e0090fe9c3ba066c65629f636bd58e4ebd9444fdba097b91af6cd3e243f"
 dependencies = [
+ "approx",
  "bevy_reflect",
  "derive_more",
- "glam 0.29.2",
- "itertools 0.13.0",
- "rand",
+ "glam",
+ "itertools 0.14.0",
+ "libm",
+ "rand 0.8.5",
  "rand_distr",
  "serde",
  "smallvec",
+ "thiserror 2.0.11",
+ "variadics_please",
 ]
 
 [[package]]
 name = "bevy_mesh"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760f3c41b4c61a5f0d956537f454c49f79b8ed0fd0781b1a879ead8e69d95283"
+checksum = "b10399c7027001edbc0406d7d0198596b1f07206c1aae715274106ba5bdcac40"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -926,85 +1012,93 @@ dependencies = [
  "bevy_image",
  "bevy_math",
  "bevy_mikktspace",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_transform",
  "bevy_utils",
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "bytemuck",
- "derive_more",
  "hexasphere",
  "serde",
- "wgpu",
+ "thiserror 2.0.11",
+ "tracing",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_mikktspace"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226f663401069ded4352ed1472a85bb1f43e2b7305d6a50e53a4f6508168e380"
+checksum = "8bb60c753b968a2de0fd279b76a3d19517695e771edb4c23575c7f92156315de"
 dependencies = [
- "glam 0.29.2",
+ "glam",
 ]
 
 [[package]]
 name = "bevy_pbr"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d54c840d4352dac51f2a27cf915ac99b2f93db008d8fb1be8d23b09d522acf"
+checksum = "d5e0b4eb871f364a0d217f70f6c41d7fdc6f9f931fa1abbf222180c03d0ae410"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_color",
  "bevy_core_pipeline",
  "bevy_derive",
+ "bevy_diagnostic",
  "bevy_ecs",
  "bevy_image",
  "bevy_math",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "bytemuck",
  "derive_more",
- "fixedbitset 0.5.7",
+ "fixedbitset",
  "nonmax",
+ "offset-allocator",
  "radsort",
  "smallvec",
  "static_assertions",
+ "thiserror 2.0.11",
+ "tracing",
 ]
 
 [[package]]
 name = "bevy_picking"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2091a495c0f9c8962abb1e30f9d99696296c332b407e1f6fe1fe28aab96a8629"
+checksum = "8ed04757938655ed8094ea1efb533f99063a8b22abffc22010c694d291522850"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_derive",
  "bevy_ecs",
- "bevy_hierarchy",
  "bevy_input",
  "bevy_math",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_time",
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
+ "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "bevy_pkv"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edeb4e116ce1a27fac170647190b73e3fa7f73fbf5bd6f63500563acd9ff6ef"
+checksum = "dfc4b8af259a17df73c58ed83cdf5756c315f72a20d356c85e64bd28e0e1d569"
 dependencies = [
  "bevy_ecs",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "directories",
  "redb",
  "rmp-serde",
@@ -1016,19 +1110,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_ptr"
-version = "0.15.3"
+name = "bevy_platform"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89fe0b0b919146939481a3a7c38864face2c6d0fd2c73ab3d430dc693ecd9b11"
+checksum = "f7573dc824a1b08b4c93fdbe421c53e1e8188e9ca1dd74a414455fe571facb47"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "foldhash",
+ "getrandom 0.2.12",
+ "hashbrown 0.15.2",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "spin",
+ "web-time",
+]
+
+[[package]]
+name = "bevy_ptr"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7370d0e46b60e071917711d0860721f5347bc958bf325975ae6913a5dfcf01"
 
 [[package]]
 name = "bevy_rapier3d"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fff77c1e3140f8fa9d08632841f42cbef06e4ad98ba61d65a6297369bad763"
+checksum = "cdf74109573c2c82b05b217cb6101f7e71e6c53ad622aed6c370cc5783c59eb8"
 dependencies = [
  "bevy",
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "log",
  "nalgebra",
  "rapier3d",
@@ -1036,31 +1148,36 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ddbca0a39e88eff2c301dc794ee9d73a53f4b08d47b2c9b5a6aac182fae6217"
+checksum = "daeb91a63a1a4df00aa58da8cc4ddbd4b9f16ab8bb647c5553eb156ce36fa8c2"
 dependencies = [
  "assert_type_match",
+ "bevy_platform",
  "bevy_ptr",
  "bevy_reflect_derive",
  "bevy_utils",
  "derive_more",
  "disqualified",
- "downcast-rs",
+ "downcast-rs 2.0.2",
  "erased-serde",
- "glam 0.29.2",
+ "foldhash",
+ "glam",
  "petgraph",
  "serde",
  "smallvec",
  "smol_str",
+ "thiserror 2.0.11",
  "uuid",
+ "variadics_please",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d62affb769db17d34ad0b75ff27eca94867e2acc8ea350c5eca97d102bd98709"
+checksum = "40ddadc55fe16b45faaa54ab2f9cb00548013c74812e8b018aa172387103cce6"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1071,23 +1188,22 @@ dependencies = [
 
 [[package]]
 name = "bevy_render"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4aa9d7df5c2b65540093b8402aceec0a55d67b54606e57ce2969abe280b4c48"
+checksum = "ef91fed1f09405769214b99ebe4390d69c1af5cdd27967deae9135c550eb1667"
 dependencies = [
  "async-channel",
  "bevy_app",
  "bevy_asset",
  "bevy_color",
- "bevy_core",
  "bevy_derive",
  "bevy_diagnostic",
  "bevy_ecs",
  "bevy_encase_derive",
- "bevy_hierarchy",
  "bevy_image",
  "bevy_math",
  "bevy_mesh",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render_macros",
  "bevy_tasks",
@@ -1095,13 +1211,16 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
+ "bitflags 2.11.1",
  "bytemuck",
  "codespan-reporting",
  "derive_more",
- "downcast-rs",
+ "downcast-rs 2.0.2",
  "encase",
+ "fixedbitset",
  "futures-lite",
  "image",
+ "indexmap",
  "js-sys",
  "ktx2",
  "naga",
@@ -1111,6 +1230,9 @@ dependencies = [
  "send_wrapper",
  "serde",
  "smallvec",
+ "thiserror 2.0.11",
+ "tracing",
+ "variadics_please",
  "wasm-bindgen",
  "web-sys",
  "wgpu",
@@ -1118,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_render_macros"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3469307d1b5ca5c37b7f9269be033845357412ebad33eace46826e59da592f66"
+checksum = "abd42cf6c875bcf38da859f8e731e119a6aff190d41dd0a1b6000ad57cf2ed3d"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1130,29 +1252,30 @@ dependencies = [
 
 [[package]]
 name = "bevy_scene"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfe819202aa97bbb206d79fef83504b34d45529810563aafc2fe02cc10e3ee4"
+checksum = "5c52ca165200995fe8afd2a1a6c03e4ffee49198a1d4653d32240ea7f217d4ab"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_derive",
  "bevy_ecs",
- "bevy_hierarchy",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_transform",
  "bevy_utils",
  "derive_more",
  "serde",
+ "thiserror 2.0.11",
  "uuid",
 ]
 
 [[package]]
 name = "bevy_sprite"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27411a31704117002787c9e8cc1f2f89babf5e67572508aa029366d4643f8d01"
+checksum = "6ccae7bab2cb956fb0434004c359e432a3a1a074a6ef4eb471f1fb099f0b620b"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1162,42 +1285,41 @@ dependencies = [
  "bevy_ecs",
  "bevy_image",
  "bevy_math",
- "bevy_picking",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_transform",
  "bevy_utils",
- "bevy_window",
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "bytemuck",
  "derive_more",
- "fixedbitset 0.5.7",
- "guillotiere",
+ "fixedbitset",
  "nonmax",
  "radsort",
- "rectangle-pack",
- "serde",
+ "tracing",
 ]
 
 [[package]]
 name = "bevy_state"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243a72266f81452412f7a3859e5d11473952a25767dc29c8d285660330f007ba"
+checksum = "155d3cd97b900539008cdcaa702f88b724d94b08977b8e591a32536ce66faa8c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
- "bevy_hierarchy",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_state_macros",
  "bevy_utils",
+ "log",
+ "variadics_please",
 ]
 
 [[package]]
 name = "bevy_state_macros"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022eb069dfd64090fd92ba4a7f235383e49aa1c0f4320dab4999b23f67843b36"
+checksum = "2481c1304fd2a1851a0d4cb63a1ce6421ae40f3f0117cbc9882963ee4c9bb609"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1224,33 +1346,41 @@ dependencies = [
 
 [[package]]
 name = "bevy_tasks"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028630ddc355563bd567df1076db3515858aa26715ddf7467d2086f9b40e5ab1"
+checksum = "5b674242641cab680688fc3b850243b351c1af49d4f3417a576debd6cca8dcf5"
 dependencies = [
  "async-channel",
  "async-executor",
+ "async-task",
+ "atomic-waker",
+ "bevy_platform",
+ "cfg-if",
  "concurrent-queue",
+ "crossbeam-queue",
+ "derive_more",
  "futures-channel",
  "futures-lite",
+ "heapless",
  "pin-project",
  "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "bevy_text"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872b0b627cedf6d1bd97b75bc4d59c16f67afdd4f2fed8f7d808a258d6cb982e"
+checksum = "1d76c85366159f5f54110f33321c76d8429cfd8f39638f26793a305dae568b60"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_color",
  "bevy_derive",
  "bevy_ecs",
- "bevy_hierarchy",
  "bevy_image",
+ "bevy_log",
  "bevy_math",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_sprite",
@@ -1258,47 +1388,52 @@ dependencies = [
  "bevy_utils",
  "bevy_window",
  "cosmic-text",
- "derive_more",
  "serde",
  "smallvec",
  "sys-locale",
+ "thiserror 2.0.11",
+ "tracing",
  "unicode-bidi",
 ]
 
 [[package]]
 name = "bevy_time"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2051ec56301b994f7c182a2a6eb1490038149ad46d95eee715e1a922acdfd9"
+checksum = "bc98eb356c75be04fbbc77bb3d8ffa24c8bacd99f76111cee23d444be6ac8c9c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
+ "bevy_platform",
  "bevy_reflect",
- "bevy_utils",
  "crossbeam-channel",
+ "log",
  "serde",
 ]
 
 [[package]]
 name = "bevy_transform"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8109b1234b0e58931f51df12bc8895daa69298575cf92da408848f79a4ce201"
+checksum = "df218e440bb9a19058e1b80a68a031c887bcf7bd3a145b55f361359a2fa3100d"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
- "bevy_hierarchy",
+ "bevy_log",
  "bevy_math",
  "bevy_reflect",
+ "bevy_tasks",
+ "bevy_utils",
  "derive_more",
  "serde",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "bevy_ui"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e534590222d044c875bf3511e5d0b3da78889bb21ad797953484ce011af77b46"
+checksum = "ea4a4d2ba51865bc3039af29a26b4f52c48b54cc758369f52004caf4b6f03770"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1308,11 +1443,10 @@ dependencies = [
  "bevy_core_pipeline",
  "bevy_derive",
  "bevy_ecs",
- "bevy_hierarchy",
  "bevy_image",
  "bevy_input",
  "bevy_math",
- "bevy_picking",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_sprite",
@@ -1326,48 +1460,35 @@ dependencies = [
  "serde",
  "smallvec",
  "taffy",
+ "thiserror 2.0.11",
+ "tracing",
 ]
 
 [[package]]
 name = "bevy_utils"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63c2174d43a0de99f863c98a472370047a2bfa7d1e5cec8d9d647fb500905d9d"
+checksum = "94f7a8905a125d2017e8561beefb7f2f5e67e93ff6324f072ad87c5fd6ec3b99"
 dependencies = [
- "ahash",
- "bevy_utils_proc_macros",
- "getrandom",
- "hashbrown 0.14.3",
+ "bevy_platform",
  "thread_local",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "bevy_utils_proc_macros"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94847541f6dd2e28f54a9c2b0e857da5f2631e2201ebc25ce68781cdcb721391"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
 ]
 
 [[package]]
 name = "bevy_window"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e1e7c6713c04404a3e7cede48a9c47b76c30efc764664ec1246147f6fb9878"
+checksum = "df7e8ad0c17c3cc23ff5566ae2905c255e6986037fb041f74c446216f5c38431"
 dependencies = [
  "android-activity",
- "bevy_a11y",
  "bevy_app",
  "bevy_ecs",
  "bevy_input",
  "bevy_math",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_utils",
+ "log",
  "raw-window-handle",
  "serde",
  "smol_str",
@@ -1375,35 +1496,33 @@ dependencies = [
 
 [[package]]
 name = "bevy_winit"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e158a73d6d896b1600a61bc115017707ecb467d1a5ad49231c5e58294f6f6e13"
+checksum = "6a5e7f00c6b3b6823df5ec2a5e9067273607208919bc8c211773ebb9643c87f0"
 dependencies = [
  "accesskit",
  "accesskit_winit",
  "approx",
  "bevy_a11y",
  "bevy_app",
- "bevy_asset",
  "bevy_derive",
  "bevy_ecs",
- "bevy_hierarchy",
- "bevy_image",
  "bevy_input",
+ "bevy_input_focus",
  "bevy_log",
  "bevy_math",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
  "bevy_window",
- "bytemuck",
  "cfg-if",
  "crossbeam-channel",
  "raw-window-handle",
  "serde",
+ "tracing",
  "wasm-bindgen",
  "web-sys",
- "wgpu-types",
  "winit",
 ]
 
@@ -1419,7 +1538,7 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -1439,7 +1558,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -1479,18 +1598,18 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "bit-vec"
-version = "0.8.0"
+name = "bit_field"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
@@ -1500,12 +1619,18 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "bitstream-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-dependencies = [
- "serde",
-]
+checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
 
 [[package]]
 name = "blake3"
@@ -1564,6 +1689,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
+
+[[package]]
 name = "bumpalo"
 version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,18 +1702,18 @@ checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "bytemuck"
-version = "1.20.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.6.0"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1613,7 +1744,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "log",
  "polling",
  "rustix",
@@ -1656,7 +1787,17 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -1667,15 +1808,20 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "clang-sys"
@@ -1697,6 +1843,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colored"
@@ -1725,6 +1877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -1742,26 +1895,6 @@ name = "const-fnv1a-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
-
-[[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom",
- "once_cell",
- "tiny-keccak",
-]
 
 [[package]]
 name = "const_panic"
@@ -1877,18 +2010,18 @@ dependencies = [
 
 [[package]]
 name = "cosmic-text"
-version = "0.12.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fd57d82eb4bfe7ffa9b1cec0c05e2fd378155b47f255a67983cb4afe0e80c2"
+checksum = "e418dd4f5128c3e93eab12246391c54a20c496811131f85754dc8152ee207892"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "fontdb 0.16.2",
  "log",
  "rangemap",
- "rayon",
  "rustc-hash 1.1.0",
  "rustybuzz 0.14.1",
  "self_cell",
+ "smol_str",
  "swash",
  "sys-locale",
  "ttf-parser 0.21.1",
@@ -1922,6 +2055,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,6 +2071,12 @@ checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam"
@@ -2105,6 +2253,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "downcast-rs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
+
+[[package]]
 name = "dpi"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,9 +2284,9 @@ checksum = "a650a461c6a8ff1ef205ed9a2ad56579309853fecefc2423f73dced342f92258"
 
 [[package]]
 name = "ecolor"
-version = "0.30.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d72e9c39f6e11a2e922d04a34ec5e7ef522ea3f5a1acfca7a19d16ad5fe50f5"
+checksum = "bc4feb366740ded31a004a0e4452fbf84e80ef432ecf8314c485210229672fd1"
 dependencies = [
  "bytemuck",
  "emath",
@@ -2140,11 +2294,12 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.30.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252d52224d35be1535d7fd1d6139ce071fb42c9097773e79f7665604f5596b5e"
+checksum = "25dd34cec49ab55d85ebf70139cb1ccd29c977ef6b6ba4fe85489d6877ee9ef3"
 dependencies = [
  "ahash",
+ "bitflags 2.11.1",
  "emath",
  "epaint",
  "nohash-hasher",
@@ -2153,9 +2308,9 @@ dependencies = [
 
 [[package]]
 name = "egui_plot"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c226cae80a6ee10c4d3aaf9e33bd9e9b2f1c0116b6036bdc2a1cfc9d2d0dcc10"
+checksum = "1794c66fb727dac28dffed2e4b548e5118d1cccc331d368a35411d68725dde71"
 dependencies = [
  "ahash",
  "egui",
@@ -2170,9 +2325,9 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "emath"
-version = "0.30.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4fe73c1207b864ee40aa0b0c038d6092af1030744678c60188a05c28553515d"
+checksum = "9e4cadcff7a5353ba72b7fea76bf2122b5ebdbc68e8155aa56dfdea90083fe1b"
 dependencies = [
  "bytemuck",
 ]
@@ -2194,7 +2349,7 @@ checksum = "b0a05902cf601ed11d564128448097b98ebe3c6574bd7b6a653a3d56d54aa020"
 dependencies = [
  "const_panic",
  "encase_derive",
- "glam 0.29.2",
+ "glam",
  "thiserror 1.0.69",
 ]
 
@@ -2228,10 +2383,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "epaint"
-version = "0.30.0"
+name = "enumn"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5666f8d25236293c966fbb3635eac18b04ad1914e3bab55bc7d44b9980cafcac"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "epaint"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fcc0f5a7c613afd2dee5e4b30c3e6acafb8ad6f0edb06068811f708a67c562"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -2246,9 +2412,29 @@ dependencies = [
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.30.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f6ddac3e6ac6fd4c3d48bb8b1943472f8da0f43a4303bcd8a18aa594401c80"
+checksum = "fc7e7a64c02cf7a5b51e745a9e45f60660a286f151c238b9d397b3e923f5082f"
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "equivalent"
@@ -2283,12 +2469,6 @@ checksum = "87f253bc5c813ca05792837a0ff4b3a580336b224512d48f7eda1d7dd9210787"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
@@ -2333,6 +2513,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide 0.8.9",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2349,12 +2544,6 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
-name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
@@ -2366,7 +2555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.7.2",
 ]
 
 [[package]]
@@ -2395,9 +2584,9 @@ checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "font-types"
-version = "0.7.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3971f9a5ca983419cdc386941ba3b9e1feba01a0ab888adf78739feb2798492"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
 dependencies = [
  "bytemuck",
 ]
@@ -2540,6 +2729,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "gif"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gilrs"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2586,21 +2799,14 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.25.0"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
-dependencies = [
- "mint",
-]
-
-[[package]]
-name = "glam"
-version = "0.29.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc46dd3ec48fdd8e693a98d2b8bafae273a2d54c1de02a2a7e3d57d501f39677"
+checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
 dependencies = [
  "bytemuck",
- "rand",
+ "libm",
+ "mint",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -2612,9 +2818,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "glow"
-version = "0.14.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51fa363f025f5c111e03f13eda21162faeacb6911fe8caa0c0349f9cf0c4483"
+checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -2673,7 +2879,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "gpu-alloc-types",
 ]
 
@@ -2683,7 +2889,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2704,7 +2910,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c08c1f623a8d0b722b8b99f821eb0ba672a1618f0d3b16ddbee1cedd2dd8557"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "gpu-descriptor-types",
  "hashbrown 0.14.3",
 ]
@@ -2715,14 +2921,14 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "grid"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be136d9dacc2a13cc70bb6c8f902b414fb2641f8db1314637c6b7933411a8f82"
+checksum = "36119f3a540b086b4e436bb2b588cf98a68863470e0e880f4d0842f112a3183a"
 
 [[package]]
 name = "guillotiere"
@@ -2732,6 +2938,17 @@ checksum = "b62d5865c036cb1393e23c50693df631d3f5d7bcca4c04fe4cc0fd592e74a782"
 dependencies = [
  "euclid",
  "svg_fmt",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -2751,7 +2968,6 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
  "allocator-api2",
- "serde",
 ]
 
 [[package]]
@@ -2760,8 +2976,16 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
+ "equivalent",
  "foldhash",
+ "serde",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heapless"
@@ -2770,8 +2994,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
  "hash32",
+ "portable-atomic",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hexasphere"
@@ -2780,7 +3011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "741ab88b8cc670443da777c3daab02cebf5a3caccfc04e3c052f55c94d1643fe"
 dependencies = [
  "constgebra",
- "glam 0.29.2",
+ "glam",
 ]
 
 [[package]]
@@ -2797,6 +3028,12 @@ checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idna"
@@ -2816,8 +3053,29 @@ checksum = "cd6f44aed642f18953a158afeb30206f4d50da59fbc66ecb53c66488de73563b"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
  "num-traits",
  "png",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -2825,6 +3083,12 @@ name = "imagesize"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df19da1e92fbfec043ca97d622955381b1f3ee72a180ec999912df31b1ccd951"
+
+[[package]]
+name = "imgref"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
 
 [[package]]
 name = "immutable-chunkmap"
@@ -2837,12 +3101,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2857,7 +3123,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "inotify-sys",
  "libc",
 ]
@@ -2872,15 +3138,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
+name = "interpolate_name"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2958,6 +3223,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "jpeg-decoder"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
+
+[[package]]
 name = "js-sys"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2986,17 +3257,18 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kira"
-version = "0.8.7"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8968f1eda49cdf4f6406fd5ffe590c3ca2778a1b0e50b5684974b138a99dfb2f"
+checksum = "fb5a9f9dff5e262540b628b00d5e1a772270a962d6869f8695bb24832ff3b394"
 dependencies = [
- "atomic-arena",
  "cpal",
- "glam 0.25.0",
+ "glam",
  "mint",
+ "paste",
  "ringbuf",
  "send_wrapper",
  "symphonia",
+ "triple_buffer",
 ]
 
 [[package]]
@@ -3040,11 +3312,11 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leafwing-input-manager"
-version = "0.16.0"
-source = "git+https://github.com/Leafwing-Studios/leafwing-input-manager.git#96d6c4142287e04cd59482ca50e5af6e394a21f1"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ac3ba8262c0e42b22bb917c18ef9dbe773e2b6b279c61a4a520c5d960b5e1a"
 dependencies = [
  "bevy",
- "bevy_egui",
  "dyn-clone",
  "dyn-eq",
  "dyn-hash",
@@ -3056,8 +3328,9 @@ dependencies = [
 
 [[package]]
 name = "leafwing_input_manager_macros"
-version = "0.16.0"
-source = "git+https://github.com/Leafwing-Studios/leafwing-input-manager.git#96d6c4142287e04cd59482ca50e5af6e394a21f1"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2226cb83129176a6c634f2ce0828c2c29896ea0898fc198636f98696b8056890"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -3066,10 +3339,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libc"
 version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libloading"
@@ -3093,7 +3388,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "libc",
  "redox_syscall",
 ]
@@ -3104,7 +3399,7 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "libc",
  "redox_syscall",
 ]
@@ -3166,6 +3461,15 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
 
 [[package]]
 name = "lyon_geom"
@@ -3237,6 +3541,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3262,11 +3576,11 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "block",
  "core-graphics-types",
  "foreign-types",
@@ -3292,6 +3606,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "mint"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3299,14 +3622,14 @@ checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
 
 [[package]]
 name = "naga"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d5941e45a15b53aad4375eedf02033adb7a28931eedc31117faffa52e6a857e"
+checksum = "e380993072e52eef724eddfcde0ed013b0c023c3f0417336ed041aa9f076994e"
 dependencies = [
  "arrayvec",
  "bit-set 0.8.0",
- "bitflags 2.6.0",
- "cfg_aliases 0.1.1",
+ "bitflags 2.11.1",
+ "cfg_aliases",
  "codespan-reporting",
  "hexf-parse",
  "indexmap",
@@ -3314,16 +3637,17 @@ dependencies = [
  "pp-rs",
  "rustc-hash 1.1.0",
  "spirv",
+ "strum",
  "termcolor",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "unicode-xid",
 ]
 
 [[package]]
 name = "naga_oil"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ea1f080bb359927cd5404d0af1e5e6758f4f2d82ecfbebb0a0c434764e40f1"
+checksum = "f2464f7395decfd16bb4c33fb0cb3b2c645cc60d051bc7fb652d3720bfb20f18"
 dependencies = [
  "bit-set 0.5.3",
  "codespan-reporting",
@@ -3346,7 +3670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26aecdf64b707efd1310e3544d709c5c0ac61c13756046aaaba41be5c4f66a3b"
 dependencies = [
  "approx",
- "glam 0.29.2",
+ "glam",
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",
@@ -3374,7 +3698,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.12",
 ]
 
 [[package]]
@@ -3383,7 +3707,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "jni-sys",
  "log",
  "ndk-sys 0.5.0+25.2.9519653",
@@ -3397,7 +3721,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "jni-sys",
  "log",
  "ndk-sys 0.6.0+11769913",
@@ -3431,14 +3755,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -3455,7 +3785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6da45c8333f2e152fc665d78a380be060eb84fad8ca4c9f7ac8ca29216cff0cc"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rand_xorshift",
 ]
 
@@ -3470,10 +3800,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "nu-ansi-term"
@@ -3483,6 +3828,16 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -3522,6 +3877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -3588,7 +3944,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "block2",
  "libc",
  "objc2",
@@ -3604,7 +3960,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "block2",
  "objc2",
  "objc2-core-location",
@@ -3628,7 +3984,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -3670,7 +4026,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "block2",
  "dispatch",
  "libc",
@@ -3695,7 +4051,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -3707,7 +4063,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -3730,7 +4086,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -3762,7 +4118,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "block2",
  "objc2",
  "objc2-core-location",
@@ -3833,6 +4189,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3878,29 +4243,28 @@ dependencies = [
 
 [[package]]
 name = "parry3d"
-version = "0.17.5"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d6c81f7d291d5ba572951242779a672f73ed605fe5520045c0bccdb381e913"
+checksum = "bec55ce6f725367f8149f750575e79a8879d71b7257c02273259f9375822821f"
 dependencies = [
  "approx",
  "arrayvec",
- "bitflags 2.6.0",
- "downcast-rs",
+ "bitflags 2.11.1",
+ "downcast-rs 2.0.2",
  "either",
  "ena",
+ "hashbrown 0.15.2",
  "log",
  "nalgebra",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 5.3.0",
  "rstar",
- "rustc-hash 2.1.0",
  "serde",
  "simba",
  "slab",
- "smallvec",
  "spade",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -3917,11 +4281,11 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
-version = "0.6.4"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
- "fixedbitset 0.4.2",
+ "fixedbitset",
  "indexmap",
  "serde",
  "serde_derive",
@@ -3986,7 +4350,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.7.2",
 ]
 
 [[package]]
@@ -4001,6 +4365,21 @@ dependencies = [
  "rustix",
  "tracing",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -4066,6 +4445,34 @@ name = "profiling"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afbdc74edc00b6f6a218ca6a5364d6226a259d4b8ea1af4a0ea063f27e179f4d"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -4086,6 +4493,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radsort"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4099,7 +4512,18 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4109,7 +4533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4118,8 +4542,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.12",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -4128,7 +4558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -4137,7 +4567,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4154,27 +4584,77 @@ checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
 
 [[package]]
 name = "rapier3d"
-version = "0.22.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87360935d1a54802efe0ddf908489436bb49c84865c36c930131843c7b1dc97d"
+checksum = "a35ec3d01c4f918675411442024a1fbfb7eafdd878a6e82479ff6e461a9092fc"
 dependencies = [
  "approx",
  "arrayvec",
- "bit-vec 0.7.0",
- "bitflags 2.6.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.11.1",
  "crossbeam",
- "downcast-rs",
- "instant",
+ "downcast-rs 2.0.2",
  "log",
  "nalgebra",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 5.3.0",
  "parry3d",
+ "profiling",
  "rustc-hash 2.1.0",
  "serde",
  "simba",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "rav1e"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87ce80a7665b1cce111f8a16c1f3929f6547ce91ade6addf4ec86a8dda5ce9"
+dependencies = [
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.12.1",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "profiling",
+ "rand 0.8.5",
+ "rand_chacha",
+ "simd_helpers",
+ "system-deps",
  "thiserror 1.0.69",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.11.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5825c26fddd16ab9f515930d49028a630efec172e903483c94796cfe31893e6b"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
 ]
 
 [[package]]
@@ -4217,9 +4697,9 @@ checksum = "3b42e27ef78c35d3998403c1d26f3efd9e135d3e5121b0a4845cc5cc27547f4f"
 
 [[package]]
 name = "read-fonts"
-version = "0.22.7"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69aacb76b5c29acfb7f90155d39759a29496aebb49395830e928a9703d2eec2f"
+checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
 dependencies = [
  "bytemuck",
  "font-types",
@@ -4255,7 +4735,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.12",
  "libredox 0.0.1",
  "thiserror 1.0.69",
 ]
@@ -4311,6 +4791,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+
+[[package]]
 name = "ringbuf"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4354,7 +4840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "serde",
  "serde_derive",
 ]
@@ -4403,12 +4889,18 @@ version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustybuzz"
@@ -4432,7 +4924,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "bytemuck",
  "libm",
  "smallvec",
@@ -4445,18 +4937,12 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.7.3"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad02996bfc73da3e301efe90b1837be9ed8f4a462b6ed410aa35d00381de89f"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
 dependencies = [
  "twox-hash",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "safe_arch"
@@ -4508,6 +4994,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2fdfc24bc566f839a2da4c4295b82db7d25a24253867d5c64355abb5799bdbe"
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "send_wrapper"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4515,18 +5007,28 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4545,12 +5047,23 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
- "ryu",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
  "serde",
 ]
 
@@ -4589,6 +5102,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "simplecss"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4605,9 +5127,9 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "skrifa"
-version = "0.22.3"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1c44ad1f6c5bdd4eefed8326711b7dbda9ea45dfd36068c427d332aa382cbe"
+checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
 dependencies = [
  "bytemuck",
  "read-fonts",
@@ -4646,7 +5168,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "calloop",
  "calloop-wayland-source",
  "cursor-icon",
@@ -4667,9 +5189,9 @@ dependencies = [
 
 [[package]]
 name = "smol_str"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6845563ada680337a52d43bb0b29f396f2d911616f6573012645b9e3d048a49"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
  "serde",
 ]
@@ -4714,7 +5236,7 @@ dependencies = [
  "egui_plot",
  "leafwing-input-manager",
  "nanorand",
- "rand",
+ "rand 0.8.5",
  "rapier3d",
  "serde",
  "smallvec",
@@ -4761,8 +5283,8 @@ dependencies = [
  "lyon_tessellation",
  "noise",
  "num-traits",
- "ordered-float",
- "rand",
+ "ordered-float 4.2.0",
+ "rand 0.8.5",
  "rapier3d",
  "ron",
  "serde",
@@ -4801,7 +5323,7 @@ dependencies = [
  "bevy_ecs",
  "blake3",
  "breaking-attr",
- "rand",
+ "rand 0.8.5",
  "rand_chacha",
  "serde",
  "tracing",
@@ -4816,7 +5338,17 @@ dependencies = [
  "hashbrown 0.14.3",
  "num-traits",
  "robust",
+ "serde",
  "smallvec",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -4825,7 +5357,7 @@ version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4856,6 +5388,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "svg_fmt"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4882,9 +5436,9 @@ dependencies = [
 
 [[package]]
 name = "swash"
-version = "0.1.19"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd59f3f359ddd2c95af4758c18270eddd9c730dde98598023cdabff472c2ca2"
+checksum = "842f3cd369c2ba38966204f983eaa5e54a8e84a7d7159ed36ade2b6c335aae64"
 dependencies = [
  "skrifa",
  "yazi",
@@ -4994,17 +5548,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "taffy"
-version = "0.5.2"
+name = "system-deps"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cb893bff0f80ae17d3a57e030622a967b8dbc90e38284d9b4b1442e23873c94"
+checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
+name = "taffy"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab4f4d046dd956a47a7e1a2947083d7ac3e6aa3cfaaead36173ceaa5ab11878c"
 dependencies = [
  "arrayvec",
  "grid",
- "num-traits",
  "serde",
  "slotmap",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "termcolor"
@@ -5066,12 +5638,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-keccak"
-version = "2.0.2"
+name = "tiff"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
 dependencies = [
- "crunchy",
+ "flate2",
+ "jpeg-decoder",
+ "weezl",
 ]
 
 [[package]]
@@ -5124,10 +5698,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "toml"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.12",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -5158,6 +5747,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow 0.6.20",
 ]
@@ -5251,6 +5842,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "triple_buffer"
+version = "8.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420466259f9fa5decc654c490b9ab538400e5420df8237f84ecbe20368bcf72b"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "ttf-parser"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5270,13 +5870,9 @@ checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
-]
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
@@ -5417,13 +6013,26 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom",
- "rand",
- "serde",
+ "getrandom 0.4.2",
+ "js-sys",
+ "rand 0.10.1",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5433,10 +6042,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "variadics_please"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b6d82be61465f97d42bd1d15bf20f3b0a3a0905018f38f9d6f6962055b0b5c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"
@@ -5459,6 +6085,24 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -5528,13 +6172,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.15.2",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "wayland-backend"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "056535ced7a150d45159d3a8dc30f91a2e2d588ca0b23f70e56033622b8016f6"
 dependencies = [
  "cc",
- "downcast-rs",
+ "downcast-rs 1.2.0",
  "rustix",
  "scoped-tls",
  "smallvec",
@@ -5547,7 +6225,7 @@ version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66249d3fc69f76fd74c82cc319300faa554e9d865dab1f7cd66cc20db10b280"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "rustix",
  "wayland-backend",
  "wayland-scanner",
@@ -5559,7 +6237,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -5581,7 +6259,7 @@ version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd0ade57c4e6e9a8952741325c30bf82f4246885dca8bf561898b86d0c1f58e"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -5593,7 +6271,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b31cab548ee68c7eb155517f2212049dc151f7cd7910c2b66abfd31c3ee12bd"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -5606,7 +6284,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "782e12f6cd923c3c316130d56205ebab53f55d6666b7faddfad36cecaeeb4022"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -5675,13 +6353,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "wgpu"
-version = "23.0.1"
+name = "weezl"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f70000db37c469ea9d67defdc13024ddf9a5f1b89cb2941b812ad7cde1735a"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "wgpu"
+version = "24.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0b3436f0729f6cdf2e6e9201f3d39dc95813fad61d826c1ed07918b4539353"
 dependencies = [
  "arrayvec",
- "cfg_aliases 0.1.1",
+ "bitflags 2.11.1",
+ "cfg_aliases",
  "document-features",
  "js-sys",
  "log",
@@ -5701,14 +6386,14 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "23.0.1"
+version = "24.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d63c3c478de8e7e01786479919c8769f62a22eec16788d8c2ac77ce2c132778a"
+checksum = "7f0aa306497a238d169b9dc70659105b4a096859a34894544ca81719242e1499"
 dependencies = [
  "arrayvec",
  "bit-vec 0.8.0",
- "bitflags 2.6.0",
- "cfg_aliases 0.1.1",
+ "bitflags 2.11.1",
+ "cfg_aliases",
  "document-features",
  "indexmap",
  "log",
@@ -5719,25 +6404,25 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "23.0.1"
+version = "24.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89364b8a0b211adc7b16aeaf1bd5ad4a919c1154b44c9ce27838213ba05fd821"
+checksum = "f112f464674ca69f3533248508ee30cb84c67cf06c25ff6800685f5e0294e259"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
  "bit-set 0.8.0",
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "block",
  "bytemuck",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "core-graphics-types",
  "glow",
  "glutin_wgl_sys",
@@ -5754,6 +6439,7 @@ dependencies = [
  "ndk-sys 0.5.0+25.2.9519653",
  "objc",
  "once_cell",
+ "ordered-float 4.2.0",
  "parking_lot",
  "profiling",
  "range-alloc",
@@ -5761,7 +6447,7 @@ dependencies = [
  "renderdoc-sys",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
@@ -5771,12 +6457,14 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "610f6ff27778148c31093f3b03abc4840f9636d58d597ca2f5977433acfe0068"
+checksum = "50ac044c0e76c03a0378e7786ac505d010a873665e2d51383dcff8dd227dc69c"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "js-sys",
+ "log",
+ "serde",
  "web-sys",
 ]
 
@@ -6137,11 +6825,11 @@ dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "block2",
  "bytemuck",
  "calloop",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "concurrent-queue",
  "core-foundation 0.9.4",
  "core-graphics",
@@ -6199,6 +6887,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.100",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "x11-dl"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6242,7 +7024,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "dlib",
  "log",
  "once_cell",
@@ -6275,15 +7057,15 @@ checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "yazi"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94451ac9513335b5e23d7a8a2b61a7102398b8cca5160829d313e84c9d98be1"
+checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
 
 [[package]]
 name = "zeno"
-version = "0.2.3"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd15f8e0dbb966fd9245e7498c7e9e5055d9e5c8b676b95bd67091cd11a1e697"
+checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
@@ -6291,7 +7073,16 @@ version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.32",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive 0.8.48",
 ]
 
 [[package]]
@@ -6303,4 +7094,45 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core",
 ]

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -33,9 +33,13 @@ default = [
 ]
 
 [workspace.dependencies.bevy]
-version = "0.15.3"
+version = "0.16.0"
 default-features = false
 features = [
+    "std",
+    "async_executor",
+    "bevy_log",
+    "bevy_input_focus",
 #    "asset_processor", # only on desktop
     "animation",
     "bevy_asset",
@@ -78,21 +82,21 @@ particles = { package = "sond-bevy-particles", path = "../sond-bevy-particles" }
 macros = { package = "sond-has-macros", path = "engine/macros" }
 
 # Engine
-accesskit = "0.17.1"
-bevy_ecs = "0.15.3"
-bevy_dylib = "0.15.3"
-bevy_mesh = "0.15.3"
-bevy_rapier3d = { version = "0.28.0", default-features = false, features = ["dim3"] }
-rapier3d = { version = "0.22.0", features = ["wasm-bindgen", "serde-serialize"] }
-bevy_kira_audio = "0.21.0"
-leafwing-input-manager = { git = "https://github.com/Leafwing-Studios/leafwing-input-manager.git", version = "0.16.0", features = ["timing"] }
+accesskit = "0.18.0"
+bevy_ecs = "0.16.0"
+bevy_dylib = "0.16.0"
+bevy_mesh = "0.16.0"
+bevy_rapier3d = { version = "0.30.0", default-features = false, features = ["dim3"] }
+rapier3d = { version = "0.25.0", features = ["serde-serialize"] }
+bevy_kira_audio = "0.23.0"
+leafwing-input-manager = { version = "0.17.0", features = ["timing"] }
 
 # Util
 ab_glyph = "0.2.26"
 array-init = "2.1.0"
 atomicow = "1.0.0"
 base64 = "0.21.7"
-bevy_pkv = "0.12.0" # settings
+bevy_pkv = "0.13.0" # settings
 bevy_svg = { version = "0.13.0", path = "../vend/bevy_svg" }
 bimap = "0.6.3"
 blake3 = "1.6.1" # already in upstream deps, decent performance despite good security, only used at startup anyway
@@ -119,8 +123,8 @@ tracing = "0.1.40"
 web-time = "1.0.0"
 
 # Debugging/Editor
-bevy-inspector-egui = {  version = "0.29.1", default-features = false }
-egui_plot = "0.30.0"
+bevy-inspector-egui = {  version = "0.31.0", default-features = false }
+egui_plot = "0.31.0"
 
 # Testing
 linkme = "0.3.22"

--- a/rs/engine/Cargo.toml
+++ b/rs/engine/Cargo.toml
@@ -8,7 +8,7 @@ description = "Things that will rarely change during development."
 # TODO: This might be able to be replaced by debug_assertions now that the feature "dev_ui" exists
 debugging = []
 # TODO: Should dev_ui actually force debugging?
-dev_ui = ["debugging", "render", "bevy-inspector-egui", "egui_plot", "leafwing-input-manager/egui"]
+dev_ui = ["debugging", "render", "bevy-inspector-egui", "egui_plot", "leafwing-input-manager/ui"]
 vis_test = ["testing", "render", "linkme", "dev_ui"]
 testing = ["colored", "bevy_mesh"]
 render = [

--- a/rs/engine/src/anim.rs
+++ b/rs/engine/src/anim.rs
@@ -1,5 +1,6 @@
 use std::{
 	cmp::Ordering,
+	collections::HashMap,
 	fmt::{Debug, Formatter},
 	hash::{Hash, Hasher},
 	marker::PhantomData,
@@ -8,10 +9,9 @@ use std::{
 };
 
 use bevy::{
-	ecs::{query::QueryEntityError, system::EntityCommands},
+	ecs::{component::Mutable, query::QueryEntityError, system::EntityCommands},
 	prelude::*,
 	transform::TransformSystem::TransformPropagate,
-	utils::HashMap,
 };
 
 use crate::util::{Diff, Target};
@@ -25,7 +25,6 @@ impl Plugin for BuiltinAnimations {
 			AnimationPlugin::<Transform>::PLUGIN,
 			AnimationPlugin::<GlobalTransform>::PLUGIN,
 			AnimationPlugin::<Visibility>::PLUGIN,
-			AnimationPlugin::<ViewVisibility>::PLUGIN,
 		))
 		.add_systems(
 			PostUpdate,
@@ -46,11 +45,11 @@ impl Plugin for BuiltinAnimations {
 #[derive(Default, Debug)]
 pub struct AnimationPlugin<T: Component>(PhantomData<T>);
 
-impl<T: Component> AnimationPlugin<T> {
+impl<T: Component<Mutability = Mutable>> AnimationPlugin<T> {
 	pub const PLUGIN: Self = Self(PhantomData::<T>);
 }
 
-impl<T: Component> Plugin for AnimationPlugin<T> {
+impl<T: Component<Mutability = Mutable>> Plugin for AnimationPlugin<T> {
 	fn build(&self, app: &mut App) {
 		app.add_event::<ComponentDelta<T>>().add_systems(
 			PostUpdate,
@@ -121,7 +120,7 @@ impl<T> Hash for AnimationSet<T> {
 	}
 }
 
-pub fn apply_animations<T: Component>(
+pub fn apply_animations<T: Component<Mutability = Mutable>>(
 	mut q: Query<&mut T>,
 	mut ticks: ResMut<Events<ComponentDelta<T>>>,
 ) {
@@ -353,7 +352,7 @@ impl<T: Resource> DynResAnimation<T> {
 		mut sender: EventWriter<Delta<T>>,
 	) {
 		for (id, mut this) in &mut animations {
-			sender.send(this(
+			sender.write(this(
 				Res::clone(&target),
 				Res::clone(&t),
 				AnimationController {
@@ -375,7 +374,7 @@ impl<T: Component> DynAnimation<T> {
 		for (id, mut this) in &mut animations {
 			let Self(target, ref mut apply) = *this;
 			let mut ctrl = AnimationController {
-				cmds: if let Some(cmds) = cmds.get_entity(id) {
+				cmds: if let Ok(cmds) = cmds.get_entity(id) {
 					cmds
 				} else {
 					continue;
@@ -383,7 +382,7 @@ impl<T: Component> DynAnimation<T> {
 			};
 			match targets.get(target) {
 				Ok((id, val)) => {
-					sender.send(apply(id, val, Res::clone(&t), ctrl));
+					sender.write(apply(id, val, Res::clone(&t), ctrl));
 				}
 				Err(e) => {
 					error!("{e}");
@@ -527,7 +526,7 @@ impl BlendTargets {
 	pub fn animate(
 		mut cmds: Commands,
 		mut global_xforms: Query<&GlobalTransform>,
-		parents: Query<&Parent>,
+		parents: Query<&ChildOf>,
 		mut animations: Query<(Entity, &mut Self)>,
 		mut sender: EventWriter<ComponentDelta<Transform>>,
 		t: Res<Time>,
@@ -586,7 +585,7 @@ impl BlendTargets {
 			};
 			let new_global = from_global + (to_global.delta_from(&from_global) * progress);
 			let new = if let Ok(parent) = parents.get(state.animated) {
-				match global_xforms.get(parent.get()) {
+				match global_xforms.get(parent.parent()) {
 					Ok(parent_global) => {
 						GlobalTransform::from(new_global).reparented_to(parent_global)
 					}
@@ -599,7 +598,7 @@ impl BlendTargets {
 			} else {
 				new_global
 			};
-			sender.send(ComponentDelta::<Transform>::diffable(
+			sender.write(ComponentDelta::<Transform>::diffable(
 				state.animated,
 				progress,
 				new,
@@ -632,7 +631,7 @@ mod tests {
 				for Slide(target, vel) in animations.iter().copied() {
 					match q.get(target) {
 						Ok(_) => {
-							sender.send(ComponentDelta::<Transform>::indefinite(
+							sender.write(ComponentDelta::<Transform>::indefinite(
 								target,
 								move |mut xform| xform.translation += vel * dt,
 							));

--- a/rs/engine/src/input.rs
+++ b/rs/engine/src/input.rs
@@ -7,11 +7,11 @@ use bevy::{
 	prelude::*,
 	reflect::{FromType, TypeRegistration},
 	state::state::States,
-	utils::HashMap,
 };
 use leafwing_input_manager::prelude::*;
 use map::detect;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use tiny_bail::prelude::r;
 
 pub mod map;

--- a/rs/engine/src/input/map/detect.rs
+++ b/rs/engine/src/input/map/detect.rs
@@ -31,10 +31,10 @@ use bevy::{
 		mouse::{MouseButtonInput, MouseMotion, MouseWheel},
 	},
 	prelude::*,
-	utils::HashMap,
 };
 use leafwing_input_manager::prelude::{MouseMoveDirection, MouseScrollDirection, UserInputWrapper};
 use smallvec::{smallvec, SmallVec};
+use std::collections::HashMap;
 
 pub struct DetectBindingPopupPlugin;
 
@@ -176,23 +176,25 @@ pub struct DetectBindingPopup;
 pub fn manage_detect_popup(
 	mut cmds: Commands,
 	state: Res<State<InputState>>,
-	q: Query<(Entity, Option<&Parent>), With<DetectBindingPopup>>,
+	q: Query<(Entity, Option<&ChildOf>), With<DetectBindingPopup>>,
 	// Popups always show right in front of camera
 	anchor: Query<Entity, (With<GlobalUi>, With<PopupsRoot>)>,
 ) {
-	let Ok((id, parent)) = q.get_single() else {
+	let Ok((id, parent)) = q.single() else {
 		return;
 	};
-	let root = anchor.single();
+	let Ok(root) = anchor.single() else {
+		return;
+	};
 	if *state.get() == DetectingBinding {
 		if let Some(parent) = parent {
-			debug_assert_eq!(parent.get(), root)
+			debug_assert_eq!(parent.parent(), root)
 		} else {
-			cmds.entity(id).set_parent(root);
+			cmds.entity(id).insert(ChildOf(root));
 		}
 	} else if parent.is_some() {
-		debug_assert_eq!(parent.unwrap().get(), root);
-		cmds.entity(id).remove_parent();
+		debug_assert_eq!(parent.unwrap().parent(), root);
+		cmds.entity(id).remove::<ChildOf>();
 	}
 }
 
@@ -211,7 +213,7 @@ pub fn display_curr_chord(
 ) {
 	let icon_mat = icon_mat.get_or_insert_with(|| mats.add(UiMatBuilder::default()));
 	let outline_mat = mats.add(MeshOutline::default_material());
-	let Ok((id, mut icons)) = q.get_single_mut() else {
+	let Ok((id, mut icons)) = q.single_mut() else {
 		return;
 	};
 
@@ -219,7 +221,7 @@ pub fn display_curr_chord(
 		let keep = curr_chord.contains_key(entry);
 		if !keep {
 			for id in ids.iter() {
-				cmds.entity(*id).despawn_recursive()
+				cmds.entity(*id).despawn()
 			}
 		}
 		keep
@@ -292,7 +294,7 @@ pub fn detect_bindings(
 		*w = Vec2::ZERO;
 		let binding = ToBind(std::mem::take(chord));
 		info!("{binding:?}");
-		tx.send(binding);
+		tx.write(binding);
 	};
 
 	// Only finalize binding when the user *releases* at least one button.

--- a/rs/engine/src/input/map/icons.rs
+++ b/rs/engine/src/input/map/icons.rs
@@ -2,17 +2,19 @@ use crate::input::{
 	map::{icons::kenney::generic_base_dir, Platform},
 	SerializableUserInputWrapper,
 };
-use bevy::{
-	asset::AssetPath,
-	input::keyboard::Key,
-	prelude::*,
-	utils::{HashMap, HashSet},
-};
+use bevy::{asset::AssetPath, input::keyboard::Key, prelude::*};
 use dyn_clone::clone_box;
 use leafwing_input_manager::{clashing_inputs::BasicInputs, prelude::*};
 use serde::{Deserialize, Serialize};
 use smol_str::{SmolStr, ToSmolStr};
-use std::{any::Any, hash::Hash, ops::Index, path::PathBuf, sync::Arc};
+use std::{
+	any::Any,
+	collections::{HashMap, HashSet},
+	hash::Hash,
+	ops::Index,
+	path::PathBuf,
+	sync::Arc,
+};
 
 pub fn default_icon() -> AssetPath<'static> {
 	PathBuf::from("ui/Kenney/input-prompts/Flairs/Vector/flair_circle_red_8.svg").into()

--- a/rs/engine/src/input/map/widgets.rs
+++ b/rs/engine/src/input/map/widgets.rs
@@ -78,8 +78,8 @@ impl InputIcon {
 				outline,
 				ref outline_material,
 			} = *this;
-			if let Some(text_entity) = cmds.get_entity(text_entity) {
-				text_entity.despawn_recursive();
+			if let Ok(mut text_entity) = cmds.get_entity(text_entity) {
+				text_entity.despawn();
 			}
 			let mut cmds = cmds.entity(id);
 			let svg = asset_server.load::<Svg>(image);

--- a/rs/engine/src/lib.rs
+++ b/rs/engine/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(unused_crate_dependencies)]
 
+use accesskit as _;
 use bevy::app::{App, Plugin};
 #[allow(unused_imports, clippy::single_component_path_imports)]
 #[cfg(all(feature = "bevy_dylib", not(target_arch = "wasm32")))]

--- a/rs/engine/src/mats/fog.rs
+++ b/rs/engine/src/mats/fog.rs
@@ -1,5 +1,5 @@
 use bevy::{
-	asset::{Asset, ReflectAsset},
+	asset::{weak_handle, Asset, ReflectAsset},
 	image::{ImageAddressMode, ImageFilterMode, ImageSampler, ImageSamplerDescriptor, ImageType},
 	pbr::{ExtendedMaterial, MaterialExtension},
 	prelude::*,
@@ -18,8 +18,7 @@ use crate::{
 };
 
 pub type Matter = ExtendedMaterial<StandardMaterial, DistanceDither>;
-pub const BAYER_HANDLE: Handle<Image> =
-	Handle::weak_from_u128(92299220200241619468604683494190943784);
+pub const BAYER_HANDLE: Handle<Image> = weak_handle!("45702ee6-5faa-a602-c3eb-8155497b0e28");
 
 /// Function instead of a constant because it uses floating-point math.
 #[inline(always)]

--- a/rs/engine/src/nav.rs
+++ b/rs/engine/src/nav.rs
@@ -3,9 +3,12 @@ use crate::{
 	planet::chunks::ChunkIndex,
 	util::Todo,
 };
-use bevy::{prelude::*, utils::HashMap};
+use bevy::prelude::*;
 use rapier3d::prelude::*;
-use std::{collections::HashSet, sync::Weak};
+use std::{
+	collections::{HashMap, HashSet},
+	sync::Weak,
+};
 
 pub mod alg;
 pub mod heightmap;

--- a/rs/engine/src/nav/heightmap.rs
+++ b/rs/engine/src/nav/heightmap.rs
@@ -1,8 +1,8 @@
 use super::{EdgeVendor, NavEdge, NavEdgeFilter, NavGraph, NavIdx, PlanetTri};
 use crate::planet::chunks::{ChunkIndex, CHUNK_COLS, CHUNK_ROWS};
-use bevy::{prelude::*, utils::HashMap};
+use bevy::prelude::*;
 use rapier3d::geometry::HeightField;
-use std::{f32::consts::SQRT_2, sync::Weak};
+use std::{collections::HashMap, f32::consts::SQRT_2, sync::Weak};
 
 pub trait FnsThatShouldBePub {
 	fn num_triangles(&self) -> usize;

--- a/rs/engine/src/planet/frame.rs
+++ b/rs/engine/src/planet/frame.rs
@@ -7,8 +7,9 @@ use crate::{
 };
 use bevy::{prelude::*, render::view::RenderLayers};
 use bevy_rapier3d::{
-	dynamics::RapierRigidBodyHandle, na::Vector, plugin::RapierContext,
-	prelude::TransformInterpolation,
+	dynamics::RapierRigidBodyHandle,
+	na::Vector,
+	prelude::{TransformInterpolation, WriteRapierContext},
 };
 use particles::{
 	InitialGlobalTransform, InitialTransform, PreviousGlobalTransform, PreviousTransform,
@@ -56,26 +57,26 @@ impl Default for Frame {
 }
 
 pub fn reframe_all_entities(
-	mut ctx: Single<&mut RapierContext>,
+	mut ctx: WriteRapierContext,
 	mut q: Query<(
 		&mut Transform,
 		&mut GlobalTransform,
-		Has<Parent>,
+		Has<ChildOf>,
 		Option<&RenderLayers>,
 	)>,
 	bodies: Query<&RapierRigidBodyHandle>,
-	mut interpolations: Query<&mut TransformInterpolation, Without<Parent>>,
-	mut prev_xforms: Query<&mut Prev<Transform>, Without<Parent>>,
+	mut interpolations: Query<&mut TransformInterpolation, Without<ChildOf>>,
+	mut prev_xforms: Query<&mut Prev<Transform>, Without<ChildOf>>,
 	mut prev_globals: Query<&mut Prev<GlobalTransform>>,
 	mut prev_particles: Query<(
 		&mut PreviousTransform,
 		&mut PreviousGlobalTransform,
-		Has<Parent>,
+		Has<ChildOf>,
 	)>,
 	mut init_particles: Query<(
 		&mut InitialTransform,
 		&mut InitialGlobalTransform,
-		Has<Parent>,
+		Has<ChildOf>,
 	)>,
 	frame: Res<Frame>,
 	prev_frame: Res<Prev<Frame>>,
@@ -130,10 +131,13 @@ pub fn reframe_all_entities(
 		});
 
 	// Rapier transforms
+	let Ok(mut ctx) = ctx.single_mut() else {
+		return;
+	};
 	let offset = Vector::from(offset);
 	for body in &bodies {
 		// TODO: Parallelize this -- RigidBodySet does not have par_iter
-		if let Some(body) = ctx.bodies.get_mut(body.0) {
+		if let Some(body) = ctx.rigidbody_set.bodies.get_mut(body.0) {
 			let pos = body.translation();
 			body.set_translation(*pos + offset, false);
 		}

--- a/rs/engine/src/planet/sky.rs
+++ b/rs/engine/src/planet/sky.rs
@@ -95,7 +95,7 @@ pub struct SkyPipeline {
 impl FromWorld for SkyPipeline {
 	fn from_world(world: &mut World) -> Self {
 		let render_device = world.resource::<RenderDevice>();
-		let mut entries = SkyCubeUniforms::bind_group_layout_entries(render_device);
+		let mut entries = SkyCubeUniforms::bind_group_layout_entries(render_device, false);
 		entries.push(BindGroupLayoutEntry {
 			binding: 1,
 			visibility: ShaderStages::VERTEX_FRAGMENT,
@@ -313,7 +313,7 @@ fn prepare_sky_bind_groups(
 				let storage_buffers = Res::clone(&storage_buffers);
 				let uniforms = SkyCubeUniforms {
 					face_index: i as _,
-					face_width: skybox.size.x,
+					face_width: skybox.size.width,
 					face_rotation: FACE_ROTATIONS[i],
 					rotation: cube_rotation,
 					time_of_day: day_night.time_of_day as f32,
@@ -325,6 +325,7 @@ fn prepare_sky_bind_groups(
 					&SkyCubeUniforms::bind_group_layout(&render_device),
 					&render_device,
 					&mut (images, fallback_image, storage_buffers),
+					false,
 				)
 				.unwrap();
 				render_device.create_bind_group(

--- a/rs/engine/src/planet/terrain.rs
+++ b/rs/engine/src/planet/terrain.rs
@@ -10,7 +10,6 @@ use bevy::{
 		mesh::{PrimitiveTopology, VertexAttributeValues::Float32x3},
 		render_asset::RenderAssetUsages,
 	},
-	utils::HashMap,
 };
 use bevy_rapier3d::{
 	geometry::shape_views::HeightFieldCellStatus,
@@ -19,6 +18,7 @@ use bevy_rapier3d::{
 	prelude::*,
 };
 use rapier3d::{geometry::HeightField, na::DMatrix};
+use std::collections::HashMap;
 use web_time::{Duration, Instant};
 
 use crate::{

--- a/rs/engine/src/testing.rs
+++ b/rs/engine/src/testing.rs
@@ -2,7 +2,6 @@ use bevy::{
 	app::AppExit,
 	log::{error, info},
 	prelude::*,
-	utils::HashMap,
 };
 use bevy_rapier3d::{
 	math::Vect,
@@ -10,6 +9,7 @@ use bevy_rapier3d::{
 };
 use colored::Colorize;
 use std::{
+	collections::HashMap,
 	error::Error,
 	fmt::{Display, Formatter},
 	num::NonZero,
@@ -30,7 +30,9 @@ pub fn new_test_app() -> App {
 			close_when_requested: false,
 			..default()
 		}))
-		.add_plugins(bevy_inspector_egui::bevy_egui::EguiPlugin)
+		.add_plugins(bevy_inspector_egui::bevy_egui::EguiPlugin {
+			enable_multipass_for_primary_context: true,
+		})
 		.insert_resource(bevy::winit::WinitSettings { ..default() })
 		.add_plugins(bevy_rapier3d::render::RapierDebugRenderPlugin {
 			enabled: true,
@@ -93,7 +95,7 @@ pub fn timeout(mut timer: ResMut<Timeout>, t: Res<Time>) {
 }
 
 pub fn exit_app(mut events: EventWriter<AppExit>) {
-	events.send(AppExit::Success);
+	events.write(AppExit::Success);
 }
 
 #[derive(Event)]
@@ -188,11 +190,11 @@ fn check_test_results(
 		} else {
 			error!("1 test failed");
 		}
-		exits.send(AppExit::Error(
+		exits.write(AppExit::Error(
 			failed.try_into().unwrap_or(NonZero::<u8>::MAX),
 		));
 	} else {
-		exits.send(AppExit::Success);
+		exits.write(AppExit::Success);
 	}
 }
 
@@ -204,7 +206,7 @@ impl<F: IntoSystem<(), TestStatus, M>, M> TestSystem<M> for F {
 	fn test(self, test_name: &'static str) -> impl System<In = (), Out = ()> {
 		let status_to_event = move |In(status): In<TestStatus>,
 		                            mut events: EventWriter<TestEvent>| {
-			events.send(TestEvent {
+			events.write(TestEvent {
 				status,
 				name: test_name,
 			});
@@ -330,12 +332,13 @@ pub mod vis {
 
 			if input.just_pressed(KeyCode::KeyF) {
 				commands.entity(entity).despawn();
-				events.send(TestStatus::Failed("user pressed F".into()).event(test_window.test_id));
+				events
+					.write(TestStatus::Failed("user pressed F".into()).event(test_window.test_id));
 			} else if input.just_pressed(KeyCode::KeyP) {
 				commands.entity(entity).despawn();
-				events.send(TestStatus::Passed.event(test_window.test_id));
+				events.write(TestStatus::Passed.event(test_window.test_id));
 			} else {
-				events.send(TestStatus::Running.event(test_window.test_id));
+				events.write(TestStatus::Running.event(test_window.test_id));
 			}
 		}
 	}

--- a/rs/engine/src/ui.rs
+++ b/rs/engine/src/ui.rs
@@ -9,9 +9,14 @@ use crate::{
 	util::{Diff, LerpSlerp},
 };
 use bevy::{
+	asset::weak_handle,
 	color::palettes::basic::YELLOW,
 	diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin},
-	ecs::{query::QuerySingleError, schedule::SystemConfigs, system::EntityCommands},
+	ecs::{
+		query::QuerySingleError,
+		schedule::{IntoScheduleConfigs, ScheduleConfigs},
+		system::{EntityCommands, ScheduleSystem},
+	},
 	input::common_conditions::input_toggle_active,
 	prelude::*,
 	render::{
@@ -19,12 +24,11 @@ use bevy::{
 		view::{Layer, RenderLayers},
 	},
 	ui::FocusPolicy,
-	utils::HashMap,
 };
 use leafwing_input_manager::{prelude::*, Actionlike};
 use serde::{Deserialize, Serialize};
 use std::{
-	collections::VecDeque,
+	collections::{HashMap, VecDeque},
 	f64::consts::TAU,
 	fmt::Formatter,
 	ops::{Add, ControlFlow::Break, Mul},
@@ -74,7 +78,10 @@ impl Plugin for UiPlugin {
 			.insert_gizmo_config(
 				focus::FocusGizmos::<GLOBAL_UI_LAYER>,
 				GizmoConfig {
-					line_width: 6.0,
+					line: GizmoLineConfig {
+						width: 6.0,
+						..default()
+					},
 					render_layers: GLOBAL_UI_RENDER_LAYERS,
 					..default()
 				},
@@ -94,6 +101,8 @@ impl Plugin for UiPlugin {
 		.register_type::<DitherFade>()
 		.register_type::<Text3d>()
 		.init_resource::<ActionState<UiAction>>()
+		.init_resource::<bevy::input_focus::InputFocus>()
+		.init_resource::<bevy::input_focus::InputFocusVisible>()
 		.insert_resource(UiAction::default_mappings())
 		.init_resource::<UiHovered>()
 		.init_resource::<TextMeshCache>()
@@ -139,7 +148,7 @@ impl Plugin for UiPlugin {
 		let mono = srv.load("ui/fonts/Noto_Sans_Mono/static/NotoSansMono-Bold.ttf");
 		app.insert_resource(UiFonts { mono });
 		app.world_mut().resource_mut::<Assets<_>>().insert(
-			Handle::weak_from_u128(widgets::UNLIT_MATERIAL_ID).id(),
+			weak_handle!("6b6be46f-1849-6085-002c-70718ef1e41b").id(),
 			new_unlit_material(),
 		);
 	}
@@ -461,12 +470,12 @@ pub struct PopupsRoot;
 pub struct Popup;
 
 pub fn hide_orphaned_popups(
-	mut q: Query<(Option<&Parent>, &mut Visibility), With<Popup>>,
+	mut q: Query<(Option<&ChildOf>, &mut Visibility), With<Popup>>,
 	// Popups are spawned on `CamAnchor`
 	roots: Query<(), With<PopupsRoot>>,
 ) {
 	for (parent, mut vis) in &mut q {
-		match (parent.map(Parent::get), *vis) {
+		match (parent.map(ChildOf::parent), *vis) {
 			(Some(parent), Visibility::Hidden) if roots.contains(parent) => {
 				*vis = Visibility::Inherited
 			}
@@ -516,7 +525,7 @@ pub fn show_fps(
 	ui_fonts: Res<UiFonts>,
 ) {
 	if keys.just_pressed(KeyCode::F10) {
-		match q.get_single() {
+		match q.single() {
 			Err(QuerySingleError::NoEntities(_)) => {
 				let val = diags
 					.get_measurement(&FrameTimeDiagnosticsPlugin::FPS)
@@ -562,36 +571,38 @@ pub struct ShowDebugWindows;
 pub trait AddDebugUi {
 	/// Like `App::add_systems`, but disables the systems when the `debugging` feature
 	/// is not enabled.
-	fn add_debug_systems<M>(&mut self, systems: impl IntoSystemConfigs<M>) -> &mut Self;
+	fn add_debug_systems<M>(
+		&mut self,
+		systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
+	) -> &mut Self;
 }
 
 impl AddDebugUi for App {
 	#[inline(always)]
-	fn add_debug_systems<M>(&mut self, _systems: impl IntoSystemConfigs<M>) -> &mut Self {
+	fn add_debug_systems<M>(
+		&mut self,
+		_systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
+	) -> &mut Self {
 		#[cfg(feature = "debugging")]
 		self.add_systems(Update, _systems.in_set(ShowDebugWindows));
 		self
 	}
 }
 
-pub trait ToggleDbgUi<M> {
+pub trait ToggleDbgUi<M>: IntoScheduleConfigs<ScheduleSystem, M> + Sized {
 	/// Debug UI window will be hidden by default, and can be shown by pressing the given
 	/// key while the debug interface is visible.
-	fn show_with(self, key: KeyCode) -> SystemConfigs;
-	/// Debug UI window will be visible by default, and can be hidden by pressing the given
-	/// key while the debug interface is visible.
-	fn hide_with(self, key: KeyCode) -> SystemConfigs;
-}
-
-impl<S: IntoSystemConfigs<M>, M> ToggleDbgUi<M> for S {
-	fn show_with(self, key: KeyCode) -> SystemConfigs {
+	fn show_with(self, key: KeyCode) -> ScheduleConfigs<ScheduleSystem> {
 		self.run_if(dbg_window_toggled(false, key))
 	}
-
-	fn hide_with(self, key: KeyCode) -> SystemConfigs {
+	/// Debug UI window will be visible by default, and can be hidden by pressing the given
+	/// key while the debug interface is visible.
+	fn hide_with(self, key: KeyCode) -> ScheduleConfigs<ScheduleSystem> {
 		self.run_if(dbg_window_toggled(true, key))
 	}
 }
+
+impl<S: IntoScheduleConfigs<ScheduleSystem, M>, M> ToggleDbgUi<M> for S {}
 
 pub fn dbg_window_toggled(default: bool, code: KeyCode) -> impl Condition<()> {
 	input_toggle_active(false, KeyCode::Backquote).and(input_toggle_active(default, code))
@@ -653,7 +664,7 @@ pub fn pop_on_back_observer(
 	let entity = trigger.observer();
 	let Ok(fade) = fade.get(entity) else { return };
 	cmds.entity(entity).fade_out_secs(**fade);
-	let Ok(mut stack) = stack.get_single_mut() else {
+	let Ok(mut stack) = stack.single_mut() else {
 		error!("couldn't find `MenuStack`");
 		return;
 	};
@@ -816,8 +827,8 @@ pub fn propagate_fade<M: Material + AsMut<DitherFade>>(
 		}
 
 		let mut defer = |id| {
-			if let Err(e) = to_set.try_insert(id, **fade) {
-				if cfg!(debug_assertions) && e.value != **fade {
+			if let Some(existing) = to_set.insert(id, **fade) {
+				if cfg!(debug_assertions) && existing != **fade {
 					error!("Separate `Fade` tree branches are sharing a material");
 				}
 			}
@@ -1178,11 +1189,11 @@ fn toggle_test_menu(
 	mut q: Query<(Entity, &TestMenu)>,
 	mut stack: Query<&mut MenuStack, With<GlobalUi>>,
 	input: Res<ButtonInput<KeyCode>>,
-	mut focus: ResMut<bevy::a11y::Focus>,
+	mut focus: ResMut<bevy::input_focus::InputFocus>,
 	mut state: ResMut<crate::util::StateStack<crate::input::InputState>>,
 	mut i: Local<usize>,
 ) {
-	let Ok((id, info)) = q.get_single_mut() else {
+	let Ok((id, info)) = q.single_mut() else {
 		return;
 	};
 	if input.just_pressed(KeyCode::Period) {
@@ -1191,8 +1202,8 @@ fn toggle_test_menu(
 		}
 		let child = info.faces[*i];
 
-		**focus = Some(child);
-		match stack.get_single_mut() {
+		focus.set(child);
+		match stack.single_mut() {
 			Ok(mut stack) => {
 				if *i == 0 {
 					cmds.entity(id).fade_in_secs(0.5);
@@ -1205,11 +1216,11 @@ fn toggle_test_menu(
 		};
 	}
 	if input.just_pressed(KeyCode::Comma) {
-		match stack.get_single_mut() {
+		match stack.single_mut() {
 			Ok(mut stack) => {
 				if *i == 1 {
 					cmds.entity(id).fade_out_secs(0.5);
-					**focus = None;
+					focus.clear();
 					stack.pop();
 					state.pop();
 				} else {

--- a/rs/engine/src/ui.rs
+++ b/rs/engine/src/ui.rs
@@ -126,6 +126,7 @@ impl Plugin for UiPlugin {
 				ExpandToFitChildren::apply::<CuboidPanel>,
 				ExpandToFitChildren::apply::<CylinderPanel>,
 				ExpandToFitChildren::apply::<CuboidContainer>,
+				interact::observe_interact_handlers,
 				InteractHandlers::system,
 			),
 		)
@@ -661,7 +662,7 @@ pub fn pop_on_back_observer(
 	{
 		return;
 	}
-	let entity = trigger.observer();
+	let entity = trigger.target();
 	let Ok(fade) = fade.get(entity) else { return };
 	cmds.entity(entity).fade_out_secs(**fade);
 	let Ok(mut stack) = stack.single_mut() else {

--- a/rs/engine/src/ui/dbg.rs
+++ b/rs/engine/src/ui/dbg.rs
@@ -9,8 +9,13 @@ use bevy::{
 	window::{CursorGrabMode, PrimaryWindow},
 };
 use bevy_inspector_egui::{
-	bevy_egui::EguiContext, egui, egui::Color32, inspector_options::std_options::NumberOptions,
-	prelude::*, quick::WorldInspectorPlugin, reflect_inspector::InspectorUi,
+	bevy_egui::{EguiContext, EguiPlugin},
+	egui,
+	egui::Color32,
+	inspector_options::std_options::NumberOptions,
+	prelude::*,
+	quick::WorldInspectorPlugin,
+	reflect_inspector::InspectorUi,
 };
 use bevy_rapier3d::plugin::{RapierConfiguration, TimestepMode};
 use egui_plot::{Legend, Line, Plot};
@@ -25,6 +30,12 @@ impl Plugin for DebugUiPlugin {
 	fn build(&self, app: &mut App) {
 		app.add_plugins(bevy_rapier3d::prelude::RapierDebugRenderPlugin::default())
 			.add_systems(Update, toggle_physics_wireframes);
+
+		if !app.is_plugin_added::<EguiPlugin>() {
+			app.add_plugins(EguiPlugin {
+				enable_multipass_for_primary_context: true,
+			});
+		}
 
 		app.add_plugins(
 			WorldInspectorPlugin::new().run_if(dbg_window_toggled(false, KeyCode::KeyI)),
@@ -62,11 +73,9 @@ pub fn keep_cursor_unlocked(mut windows: Query<&mut Window>) {
 }
 
 pub fn set_egui_style(mut egui_contexts: Query<&mut EguiContext, With<PrimaryWindow>>) {
-	r!(egui_contexts.get_single_mut())
-		.get_mut()
-		.style_mut(|style| {
-			style.visuals.window_fill = Color32::from_black_alpha(128);
-		});
+	r!(egui_contexts.single_mut()).get_mut().style_mut(|style| {
+		style.visuals.window_fill = Color32::from_black_alpha(128);
+	});
 }
 
 pub fn dbg_res<T: Resource + Reflect>(
@@ -75,7 +84,7 @@ pub fn dbg_res<T: Resource + Reflect>(
 	mut ui_hovered: ResMut<UiHovered>,
 	mut res: ResMut<T>,
 ) {
-	let egui_context = q.get_single_mut();
+	let egui_context = q.single_mut();
 
 	let Ok(egui_context) = egui_context else {
 		return;
@@ -103,7 +112,7 @@ pub fn dbg_proxy<T: Resource + From<Proxy>, Proxy: for<'a> From<&'a T> + Partial
 ) {
 	let mut proxy = Proxy::from(&*res);
 
-	let egui_context = q.get_single_mut();
+	let egui_context = q.single_mut();
 
 	let Ok(egui_context) = egui_context else {
 		return;
@@ -131,7 +140,7 @@ pub fn dbg_proxy<T: Resource + From<Proxy>, Proxy: for<'a> From<&'a T> + Partial
 }
 
 pub fn dbg_single_proxy<
-	T: Component + From<Proxy>,
+	T: Component<Mutability = bevy::ecs::component::Mutable> + From<Proxy>,
 	Proxy: for<'a> From<&'a T> + PartialEq<T> + Reflect,
 >(
 	mut q: Query<&mut EguiContext, With<PrimaryWindow>>,
@@ -139,11 +148,11 @@ pub fn dbg_single_proxy<
 	mut ui_hovered: ResMut<UiHovered>,
 	mut single: Query<&mut T>,
 ) {
-	let mut single = r!(single.get_single_mut());
+	let mut single = r!(single.single_mut());
 
 	let mut proxy = Proxy::from(&*single);
 
-	let egui_context = q.get_single_mut();
+	let egui_context = q.single_mut();
 
 	let Ok(egui_context) = egui_context else {
 		return;
@@ -203,7 +212,7 @@ pub fn dbg_fps(
 	mut ui_hovered: ResMut<UiHovered>,
 ) {
 	let mut hovered = false;
-	let Ok(mut ctx) = egui_contexts.get_single_mut() else {
+	let Ok(mut ctx) = egui_contexts.single_mut() else {
 		return;
 	};
 	let ctx = ctx.get_mut();

--- a/rs/engine/src/ui/focus.rs
+++ b/rs/engine/src/ui/focus.rs
@@ -1,6 +1,7 @@
 use crate::ui::{MenuRef, MenuStack, UiAction, GLOBAL_UI_RENDER_LAYERS};
 use bevy::{
-	a11y::Focus, ecs::identifier::error::IdentifierError, prelude::*, render::view::RenderLayers,
+	ecs::identifier::error::IdentifierError, input_focus::InputFocus, prelude::*,
+	render::view::RenderLayers,
 };
 use leafwing_input_manager::prelude::ActionState;
 use serde::{Deserialize, Serialize};
@@ -155,7 +156,7 @@ impl FocusTarget {
 	pub fn resolve(
 		&self,
 		from: Entity,
-		parent_query: &Query<&Parent>,
+		parent_query: &Query<&ChildOf>,
 		children_query: &Query<&Children>,
 		names: &Query<&Name>,
 		menu: &MenuRef,
@@ -164,27 +165,27 @@ impl FocusTarget {
 			Self::Sibling(relative) => parent_query
 				.get(from)
 				.ok()
-				.map(Parent::get)
+				.map(ChildOf::parent)
 				.and_then(|parent| children_query.get(parent).ok())
 				.and_then(|children| {
 					let len = children.len();
 					let i = (children
 						.iter()
-						.position(|child| *child == from)
+						.position(|child| child == from)
 						.unwrap()
 						.checked_add_signed(*relative)
 						.unwrap_or(len - 1))
 						% len;
 					children.get(i).copied()
 				}),
-			Self::ToParent => parent_query.get(from).ok().map(Parent::get),
+			Self::ToParent => parent_query.get(from).ok().map(ChildOf::parent),
 			Self::MenuRoot => Some(menu.root),
 			Self::ChildN(i) => children_query
 				.get(from)
 				.ok()
 				.and_then(|children| children.get(*i).copied()),
 			Self::FindChild(name) => children_query.get(from).ok().and_then(|children| {
-				children.iter().copied().find(|child| {
+				children.iter().find(|child| {
 					let Some(child_name) = names.get(*child).ok() else {
 						return false;
 					};
@@ -328,14 +329,14 @@ impl AdjacentWidgets {
 }
 
 pub fn handle_focus_actions(
-	q: Query<(&AdjacentWidgets, Option<&Parent>, &RenderLayers)>,
-	parents_q: Query<&Parent>,
+	q: Query<(&AdjacentWidgets, Option<&ChildOf>, &RenderLayers)>,
+	parents_q: Query<&ChildOf>,
 	children_q: Query<&Children>,
 	names: Query<&Name>,
 	mut stacks: Query<(&mut MenuStack, &RenderLayers)>,
 	actions: Query<(&ActionState<UiAction>, &RenderLayers)>,
 	glob_actions: Res<ActionState<UiAction>>,
-	mut focus: ResMut<Focus>,
+	mut focus: ResMut<InputFocus>,
 	mut prev_cursor: Local<Option<Wedge2d>>,
 ) {
 	for (state, layers) in

--- a/rs/engine/src/ui/interact.rs
+++ b/rs/engine/src/ui/interact.rs
@@ -45,6 +45,25 @@ pub fn dbg_event_observer(trigger: Trigger<Interaction>) {
 	trace!(event=?trigger.event(), entity=?trigger.observer());
 }
 
+pub fn bridge_to_handlers_observer(
+	trigger: Trigger<Interaction>,
+	handlers_q: Query<&InteractHandlers>,
+	mut cmds: Commands,
+) {
+	let entity = trigger.target();
+	let Ok(handlers) = handlers_q.get(entity) else {
+		return;
+	};
+	let mut entity_cmds = cmds.entity(entity);
+	let _ = handlers.handle(*trigger.event(), &mut entity_cmds);
+}
+
+pub fn observe_interact_handlers(mut cmds: Commands, q: Query<Entity, Added<InteractHandlers>>) {
+	for id in &q {
+		cmds.entity(id).observe(bridge_to_handlers_observer);
+	}
+}
+
 pub fn on_ok(
 	handler: impl Fn(&mut EntityCommands) -> ControlFlow<()> + Send + Sync + 'static,
 ) -> CowArc<'static, InteractHandler> {
@@ -204,7 +223,7 @@ pub fn focus_toggle_border_observer(
 		InteractionKind::Release => Visibility::Hidden,
 		InteractionKind::Hold(_) => return,
 	};
-	let entity = trigger.observer();
+	let entity = trigger.target();
 	let Ok(children) = children_q.get(entity) else {
 		warn!("no border to show focus: no children");
 		return;
@@ -249,7 +268,7 @@ pub fn focus_state_colors_observer(
 	if trigger.event().source != InteractionSource::Focus {
 		return;
 	}
-	let entity = trigger.observer();
+	let entity = trigger.target();
 	let Ok(focus) = focus_colors.get(entity) else {
 		return;
 	};
@@ -293,7 +312,7 @@ pub fn focus_state_emissive_observer(
 	if trigger.event().source != InteractionSource::Focus {
 		return;
 	}
-	let entity = trigger.observer();
+	let entity = trigger.target();
 	let Ok(focus) = focus_emissive.get(entity) else {
 		return;
 	};

--- a/rs/engine/src/ui/interact.rs
+++ b/rs/engine/src/ui/interact.rs
@@ -6,7 +6,6 @@ use atomicow::CowArc;
 use bevy::{
 	asset::{Asset, AssetId, Assets},
 	color::{Color, LinearRgba},
-	hierarchy::{Children, Parent},
 	log::{error, trace, warn},
 	pbr::MeshMaterial3d,
 	prelude::*,
@@ -449,6 +448,6 @@ pub struct Interaction {
 }
 
 impl Event for Interaction {
-	type Traversal = &'static Parent;
+	type Traversal = &'static ChildOf;
 	const AUTO_PROPAGATE: bool = true;
 }

--- a/rs/engine/src/ui/layout.rs
+++ b/rs/engine/src/ui/layout.rs
@@ -1,6 +1,6 @@
 use super::widgets::{CuboidContainer, CuboidPanel, CylinderPanel, WidgetShape};
 use crate::util::Angle;
-use bevy::prelude::*;
+use bevy::{ecs::component::Mutable, prelude::*};
 use bevy_rapier3d::{
 	parry::{
 		bounding_volume::{Aabb, BoundingVolume},
@@ -101,7 +101,7 @@ impl Default for SiblingConstraint {
 pub fn apply_constraints(
 	child_constraints: Query<(Entity, &LineUpChildren, &Children)>,
 	sibling_constraints: Query<&SiblingConstraint>,
-	mut shapes: Query<(Entity, &mut Transform, Option<&Parent>, &WidgetShape)>,
+	mut shapes: Query<(Entity, &mut Transform, Option<&ChildOf>, &WidgetShape)>,
 ) {
 	for (container, constraint, children) in &child_constraints {
 		match children.len() {
@@ -122,7 +122,6 @@ pub fn apply_constraints(
 		let mut separations = Vec::with_capacity(children.len());
 		for pair in children
 			.iter()
-			.copied()
 			.filter(|child| {
 				shapes
 					.get(*child)
@@ -241,7 +240,7 @@ impl Default for RadialChildren {
 impl RadialChildren {
 	pub fn apply(
 		q: Query<(Entity, &Self, &Children), Changed<Self>>,
-		mut xforms: Query<(&mut Transform, &Parent)>,
+		mut xforms: Query<(&mut Transform, &ChildOf)>,
 	) {
 		for (id, this, children) in &q {
 			let first = this.arrangement.first();
@@ -259,7 +258,7 @@ impl RadialChildren {
 						continue;
 					}
 				};
-				debug_assert_eq!(id, _parent.get());
+				debug_assert_eq!(id, _parent.parent());
 				let new_pos = dir * this.radius;
 				if xform.translation != new_pos {
 					xform.translation = new_pos;
@@ -307,20 +306,20 @@ pub struct ExpandToFitChildren {
 }
 
 impl ExpandToFitChildren {
-	pub fn apply<Container: Component + SetSize>(
+	pub fn apply<Container: Component<Mutability = Mutable> + SetSize>(
 		mut q: Query<(&Self, &mut Container, &Children)>,
 		children: Query<(Ref<WidgetShape>, Ref<Transform>)>,
 	) {
 		for (this, desc, kids) in &mut q {
 			let mut aabb = Aabb::new_invalid();
-			if !kids.iter().copied().any(|child| {
+			if !kids.iter().any(|child| {
 				children
 					.get(child)
 					.is_ok_and(|(shape, xform)| shape.is_changed() || xform.is_changed())
 			}) {
 				continue;
 			}
-			for child in kids.iter().copied() {
+			for child in kids.iter() {
 				let (shape, xform) = match children.get(child) {
 					Ok(child) => child,
 					Err(e) => {

--- a/rs/engine/src/ui/mouse.rs
+++ b/rs/engine/src/ui/mouse.rs
@@ -12,7 +12,7 @@ pub fn mouse_picks_focus(
 	q: Query<(&GlobalTransform, &WidgetShape)>,
 	mut menu_stacks: Query<(&mut MenuStack, &RenderLayers)>,
 	descendant_q: Query<&Children>,
-	ancestor_q: Query<&Parent>,
+	ancestor_q: Query<&ChildOf>,
 	mut events: EventReader<CursorMoved>,
 	mouse_layers: Res<MouseLayers>,
 	windows: Query<(&Window, Has<PrimaryWindow>)>,

--- a/rs/engine/src/ui/text.rs
+++ b/rs/engine/src/ui/text.rs
@@ -1,13 +1,13 @@
 use crate::ui::widgets::WidgetShape;
 use ab_glyph::{Font as _, OutlineCurve::*};
-use bevy::{prelude::*, utils::HashMap};
+use bevy::prelude::*;
 use lyon_tessellation::{
 	geometry_builder::Positions,
 	math::{Point, Vector},
 	path::builder::{NoAttributes, PathBuilder},
 	BuffersBuilder, FillOptions, FillRule, FillTessellator, VertexBuffers,
 };
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::HashMap};
 
 pub const DIGIT_STRS: [&str; 10] = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
 

--- a/rs/engine/src/ui/widgets.rs
+++ b/rs/engine/src/ui/widgets.rs
@@ -1,7 +1,6 @@
 use crate::{
 	todo_warn,
 	ui::{
-		a11y::AKNode,
 		text::{Tessellator, TextMeshCache},
 		UiMat, UiMatBuilder,
 	},
@@ -15,7 +14,6 @@ use bevy::{
 		render_asset::RenderAssetUsages,
 		view::{Layer, RenderLayers},
 	},
-	utils::HashSet,
 };
 use bevy_rapier3d::parry::{
 	math::{Isometry, Vector},
@@ -26,6 +24,7 @@ use rapier3d::parry::shape::SharedShape;
 use serde::{Deserialize, Serialize};
 use std::{
 	borrow::Cow,
+	collections::HashSet,
 	f32::consts::PI,
 	fmt::{Debug, Formatter},
 };
@@ -76,9 +75,9 @@ pub fn offset_mesh_positions(mesh: &mut Mesh, translation: Vec3, rotation: Quat)
 	Visibility,
 	InheritedVisibility,
 	ViewVisibility,
-	RenderLayers(|| crate::ui::GLOBAL_UI_RENDER_LAYERS),
+	RenderLayers = crate::ui::GLOBAL_UI_RENDER_LAYERS,
 	crate::ui::focus::AdjacentWidgets,
-	AKNode(|| AccessibilityNode(accesskit::Node::new(::accesskit::Role::Unknown))),
+	AccessibilityNode = AccessibilityNode(accesskit::Node::new(accesskit::Role::Unknown))
 )]
 pub struct Node3d;
 
@@ -299,7 +298,7 @@ impl Default for Text3d {
 impl Text3d {
 	pub fn sync_mesh(
 		mut cmds: Commands,
-		mut q: Query<(&Text3d, &mut AKNode)>,
+		mut q: Query<(&Text3d, &mut AccessibilityNode)>,
 		changed_text: Query<Entity, Changed<Text3d>>,
 		mut meshes: ResMut<Assets<Mesh>>,
 		mut cache: ResMut<TextMeshCache>,
@@ -840,6 +839,7 @@ impl WidgetShape {
 			TypedShape::RoundConvexPolyhedron(_) => {
 				todo_warn!("Gizmo for WidgetShape(RoundConvexPolyhedron)")
 			}
+			TypedShape::Voxels(_) => todo_warn!("Gizmo for WidgetShape(Voxels)"),
 			TypedShape::Custom(_) => todo_warn!("Gizmo for WidgetShape(Custom)"),
 		}
 	}

--- a/rs/engine/src/ui/widgets/borders.rs
+++ b/rs/engine/src/ui/widgets/borders.rs
@@ -41,7 +41,7 @@ pub fn sync_cuboid_panel_borders(
 	mut meshes: ResMut<Assets<Mesh>>,
 ) {
 	for (children, panel) in &panels {
-		for (id, border) in children.iter().filter_map(|child| borders.get(*child).ok()) {
+		for (id, border) in children.iter().filter_map(|child| borders.get(child).ok()) {
 			cmds.entity(id).insert(Mesh3d(
 				meshes.add(
 					PlanarPolyLine {
@@ -68,7 +68,7 @@ pub fn sync_cuboid_container_borders(
 	mut meshes: ResMut<Assets<Mesh>>,
 ) {
 	for (children, container) in &panels {
-		for (id, border) in children.iter().filter_map(|child| borders.get(*child).ok()) {
+		for (id, border) in children.iter().filter_map(|child| borders.get(child).ok()) {
 			cmds.entity(id).insert(Mesh3d(
 				meshes.add(
 					PlanarPolyLine {

--- a/rs/engine/src/util.rs
+++ b/rs/engine/src/util.rs
@@ -2,7 +2,7 @@ use crate::ui::{UiMat, UiMatBuilder};
 use bevy::{
 	asset::{io::Reader, AssetLoader, LoadContext},
 	ecs::{
-		component::ComponentId,
+		component::HookContext,
 		query::QueryFilter,
 		system::{
 			CombinatorSystem, Combine, EntityCommands, StaticSystemParam, SystemParam,
@@ -20,7 +20,6 @@ use bevy::{
 	},
 	scene::{SceneLoaderError, SceneLoaderError::RonSpannedError},
 	state::state::FreelyMutableState,
-	utils::{HashMap, HashSet},
 };
 use itertools::Itertools;
 use num_traits::NumCast;
@@ -29,7 +28,7 @@ use serde::{de::DeserializeSeed, Deserialize, Serialize};
 use std::{
 	any::TypeId,
 	cmp::Ordering,
-	collections::VecDeque,
+	collections::{HashMap, HashSet, VecDeque},
 	f32::consts::{PI, TAU},
 	hash::Hash,
 	iter::Sum,
@@ -1368,27 +1367,24 @@ macro_rules! state_matches {
 /// # fn test_entity_tree_macro(mut commands: Commands) {
 /// let root = entity_tree!(commands; (
 ///     // The bundles to spawn on the root entity
-///     TransformBundle::default(),
-///     VisibilityBundle::default();
+///     Transform::default(),
+///     Visibility::default();
 ///     #children: [
 ///         ( // First child
 ///             => |cmds| {
 ///                 // Do stuff with ChildBuilder before spawning this child
-///                 dbg!(cmds.parent_entity());
+///                 dbg!(cmds.target_entity());
 ///             };
 ///             // The bundles to spawn on the first child
-///             TransformBundle {
-///                 local: Transform::from_translation(Vec3::splat(3.0)),
-///                 ..default()
-///             },
-///             VisibilityBundle::default();
+///             Transform::from_translation(Vec3::splat(3.0)),
+///             Visibility::default();
 ///             => |cmds| {
 ///                 // Do stuff after spawning entity but before adding children
 ///                 dbg!(cmds.id());
 ///             }
 ///             #children: [(// grandchildren
-///                 TransformBundle::default(),
-///                 VisibilityBundle::default(),
+///                 Transform::default(),
+///                 Visibility::default(),
 ///             )];
 ///             // You can repeat pairs of `=> |_| {}` and `#children: []`...
 ///             => |cmds| {
@@ -1401,7 +1397,7 @@ macro_rules! state_matches {
 ///             // After each semicolon, both the closure and `#children` sections are optional.
 ///         ),
 ///         ( // Second child
-///             PbrBundle::default(),
+///             Transform::default(),
 ///         ),
 ///         // ...etc.
 ///     ]
@@ -1641,7 +1637,7 @@ impl MeshOutline {
 	pub fn sync(
 		mut cmds: Commands,
 		parents: Query<Ref<Mesh3d>>,
-		outlines: Query<(Entity, Ref<Self>, &Parent, Has<Mesh3d>)>,
+		outlines: Query<(Entity, Ref<Self>, &ChildOf, Has<Mesh3d>)>,
 		mut meshes: ResMut<Assets<Mesh>>,
 		mut events: EventReader<AssetEvent<Mesh>>,
 	) {
@@ -1654,7 +1650,7 @@ impl MeshOutline {
 			.collect::<HashSet<_>>();
 
 		for (id, this, parent, has_mesh) in &outlines {
-			let parent_mesh = match parents.get(parent.get()) {
+			let parent_mesh = match parents.get(parent.parent()) {
 				Ok(parent_mesh) => parent_mesh,
 				Err(e) => {
 					error!(?id, "couldn't get parent: {e}");
@@ -2083,8 +2079,8 @@ fn geometric_normals_impl(positions: &[[f32; 3]], indices: &Indices) -> Vec<Vec3
 pub struct PendingErasedAsset(pub UntypedHandle);
 
 impl PendingErasedAsset {
-	pub fn on_insert(mut world: DeferredWorld, entity: Entity, _id: ComponentId) {
-		let this = world.get::<Self>(entity).unwrap();
+	pub fn on_insert(mut world: DeferredWorld, ctx: HookContext) {
+		let this = world.get::<Self>(ctx.entity).unwrap();
 		let handle = this.0.clone();
 		let mut downcasters = world.resource_mut::<ErasedAssetDowncasters>();
 		let ty = handle.type_id();
@@ -2095,7 +2091,7 @@ impl PendingErasedAsset {
 			return;
 		};
 		let mut cmds = world.commands();
-		let cmds = cmds.entity(entity);
+		let cmds = cmds.entity(ctx.entity);
 		downcaster(cmds, handle);
 		let mut downcasters = world.resource_mut::<ErasedAssetDowncasters>();
 		downcasters.0.insert(ty, downcaster);
@@ -2112,13 +2108,11 @@ impl ErasedAssetDowncasters {
 		&mut self,
 		downcaster: impl FnMut(EntityCommands, UntypedHandle) + Send + Sync + 'static,
 	) {
-		if self
-			.0
-			.try_insert(TypeId::of::<A>(), Box::new(downcaster))
-			.is_err()
-		{
+		let type_id = TypeId::of::<A>();
+		if self.0.contains_key(&type_id) {
 			panic!("Downcaster already registered for {}", A::type_path());
 		}
+		self.0.insert(type_id, Box::new(downcaster));
 	}
 }
 

--- a/rs/rng/src/terrain.rs
+++ b/rs/rng/src/terrain.rs
@@ -158,7 +158,7 @@ mod tests {
 		assert_eq!(seed.clone().canonical().string(), CANON,);
 		// Note: If sources are added or removed, the sources shared between versions must remain
 		// equivalent, but it is fine to add the values for the new sources or remove old ones here.
-		#[breaking("R7grxG1H4lIOkIw-rtvEBwswSp98CxY6gby-EghXAiE=")]
+		#[breaking("B-gnSN6nEglWgYpoQQMUL6eisix4yrUqR78XdOdXaBA=")]
 		const TERRAIN_SEEDS: TerrainSeeds = TerrainSeeds {
 			base: [3921923909, 2705971270],
 			perlin: HSSeed {

--- a/rs/src/enemies/dummy.rs
+++ b/rs/src/enemies/dummy.rs
@@ -9,8 +9,7 @@ use bevy_rapier3d::{
 	dynamics::LockedAxes,
 	math::Vect,
 	na::Vector3,
-	plugin::RapierContext,
-	prelude::{Collider, RigidBody},
+	prelude::{Collider, RigidBody, WriteRapierContext},
 };
 use enum_components::{EntityEnumCommands, WithVariant};
 use rand::{prelude::IteratorRandom, Rng};
@@ -141,7 +140,7 @@ pub fn spawn_new_dummies(
 			return;
 		};
 
-		events.send(NewDummy {
+		events.write(NewDummy {
 			transform: Transform {
 				translation: Vec3::new(x, y, z + 8.0),
 				rotation: Quat::from_rotation_x(FRAC_PI_2),
@@ -155,13 +154,16 @@ pub fn spawn_new_dummies(
 pub struct DummySpawnTimer(Timer);
 
 pub fn handle_hits(
-	mut ctx: Single<&mut RapierContext>,
+	mut ctx: WriteRapierContext,
 	mut cmds: Commands,
 	#[cfg(feature = "bevy_kira_audio")] audio: Res<Audio>,
 	#[cfg(feature = "bevy_kira_audio")] sfx: Res<Sfx>,
 	dummies: Query<(Entity, &GlobalTransform), (WithVariant<Dummy>, With<Alive>)>,
 	mut events: EventReader<Hurt>,
 ) {
+	let Ok(mut ctx) = ctx.single_mut() else {
+		return;
+	};
 	for event in events.read() {
 		if let Ok((id, global)) = dummies.get(event.victim) {
 			let Some(toi) = event.hit.details else {
@@ -171,7 +173,7 @@ pub fn handle_hits(
 				.entity2body()
 				.get(&id)
 				.copied()
-				.and_then(|body| ctx.bodies.get_mut(body))
+				.and_then(|body| ctx.rigidbody_set.bodies.get_mut(body))
 			{
 				#[cfg(feature = "bevy_kira_audio")]
 				audio.play(sfx.impacts[0].clone());

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -49,7 +49,7 @@ impl Plugin for GamePlugin {
 			.register_type::<Angle>()
 			.add_plugins((
 				RapierPhysicsPlugin::<OneWayHeightFieldFilter>::default(),
-				FrameTimeDiagnosticsPlugin,
+				FrameTimeDiagnosticsPlugin::default(),
 				#[cfg(feature = "bevy_kira_audio")]
 				AudioPlugin,
 			))
@@ -92,7 +92,7 @@ impl Plugin for GamePlugin {
 }
 
 pub fn setup_physics(mut q: Query<&mut RapierConfiguration, Added<RapierConfiguration>>) {
-	let mut cfg = rq!(q.get_single_mut());
+	let mut cfg = rq!(q.single_mut());
 	*cfg = RapierConfiguration {
 		gravity: Vect::new(0.0, 0.0, -9.80665),
 		..RapierConfiguration::new(1.0)
@@ -237,7 +237,7 @@ fn fullscreen(kb: Res<ButtonInput<KeyCode>>, mut windows: Query<&mut Window, Wit
 	use bevy::window::WindowMode::*;
 
 	if kb.just_pressed(KeyCode::F11) {
-		let mut window = windows.single_mut();
+		let mut window = rq!(windows.single_mut());
 		window.mode = match window.mode {
 			Windowed => BorderlessFullscreen(MonitorSelection::Current),
 			_ => Windowed,

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -66,7 +66,7 @@ pub fn main() -> AppExit {
 			// TODO: Is there a way to just check if all assets are imported?
 			// Or is it guaranteed to happen before exit?
 			if timer.0.just_finished() {
-				exit_events.send(AppExit::Success);
+				exit_events.write(AppExit::Success);
 			} else {
 				timer.0.tick(t.delta());
 			}

--- a/rs/src/player.rs
+++ b/rs/src/player.rs
@@ -3,7 +3,7 @@ use crate::{
 	planet::{chunks::ChunkFinder, frame::Frame, PlanetVec2},
 	player::{
 		abilities::{BoosterCharge, HurtboxFilter, WeaponCharge},
-		input::PlayerInputPlugin,
+		input::{PlayerAction, PlayerInputPlugin},
 		tune::{AbilityParams, PlayerParams, PlayerPhysicsParams},
 	},
 	settings::Settings,
@@ -20,7 +20,6 @@ use bevy::{
 		primitives::Sphere,
 		view::{Layer, RenderLayers},
 	},
-	utils::{HashMap, HashSet},
 };
 use bevy_pkv::PkvStore;
 use bevy_rapier3d::{
@@ -31,7 +30,10 @@ use bevy_rapier3d::{
 };
 use camera::spawn_cameras;
 use ctrl::{CtrlState, CtrlVel};
-use engine::{planet::terrain::NeedsTerrain, ui::GLOBAL_UI_LAYER};
+use engine::{
+	planet::terrain::NeedsTerrain,
+	ui::{UiAction, GLOBAL_UI_LAYER},
+};
 use enum_components::{ERef, EntityEnumCommands, EnumComponent, WithVariant};
 use leafwing_input_manager::prelude::*;
 use nanorand::Rng;
@@ -45,6 +47,7 @@ use prefs::PlayerPrefs;
 use rapier3d::{math::Point, prelude::Aabb};
 use serde::{Deserialize, Serialize};
 use std::{
+	collections::{HashMap, HashSet},
 	f32::consts::*,
 	fmt::Formatter,
 	num::NonZeroU8,
@@ -104,7 +107,10 @@ impl Plugin for PlayerPlugin {
 					.insert_gizmo_config(
 						engine::ui::focus::FocusGizmos::<$i>,
 						GizmoConfig {
-							line_width: 6.0,
+							line: GizmoLineConfig {
+								width: 6.0,
+								..default()
+							},
 							render_layers: layers,
 							..default()
 						},
@@ -320,7 +326,7 @@ pub fn update_player_spawn_data(
 	});
 
 	if player_assets.is_added() {
-		spawn_events.send(PlayerSpawnEvent {
+		spawn_events.write(PlayerSpawnEvent {
 			id,
 			died_at: PlanetVec2::default(),
 		});
@@ -749,10 +755,8 @@ fn player_controller(
 				Transform::default(),
 				CtrlVel::default(),
 				CollisionGroups::new(Group::GROUP_1, !Group::GROUP_1),
-				InputManagerBundle {
-					input_map,
-					..default()
-				},
+				input_map,
+				ActionState::<PlayerAction>::default(),
 				CtrlState::default(),
 				BoosterCharge::default(),
 				WeaponCharge::default(),
@@ -762,10 +766,8 @@ fn player_controller(
 		builder.spawn((
 			Name::new(format!("{}.UiController", owner)),
 			owner,
-			InputManagerBundle {
-				input_map: ui_input_map,
-				..default()
-			},
+			ui_input_map,
+			ActionState::<UiAction>::default(),
 			RenderLayers::layer(player_ui_layer(*owner)),
 		));
 	});
@@ -1040,7 +1042,7 @@ pub fn reset_oob(
 	mut cmds: Commands,
 	q: Query<(&GlobalTransform, &BelongsToPlayer)>,
 	roots: Query<(&GlobalTransform, &BelongsToPlayer), WithVariant<Root>>,
-	player_nodes: Query<(Entity, &BelongsToPlayer), (Without<NeverDespawn>, Without<Parent>)>,
+	player_nodes: Query<(Entity, &BelongsToPlayer), (Without<NeverDespawn>, Without<ChildOf>)>,
 	bounds: Res<PlayerBounds>,
 	mut respawn_timers: ResMut<PlayerRespawnTimers>,
 	frame: Res<Frame>,
@@ -1058,7 +1060,7 @@ pub fn reset_oob(
 	let mut started_timers = HashSet::new();
 	for (id, owner) in &player_nodes {
 		if to_respawn.contains(owner) {
-			cmds.entity(id).despawn_recursive();
+			cmds.entity(id).despawn();
 			if !started_timers.contains(owner) {
 				started_timers.insert(*owner);
 				roots.iter().find_map(|(global, id)| {
@@ -1121,7 +1123,7 @@ pub fn orbs_follow_arms(
 		};
 		let arm_global = arm_global.compute_transform();
 		// Always 0 progress to act as default only when no other animations are running
-		sender.send(ComponentDelta::<Transform>::new(
+		sender.write(ComponentDelta::<Transform>::new(
 			id,
 			0.0,
 			move |mut val, coef| {
@@ -1148,7 +1150,7 @@ pub fn countdown_respawn(
 	for (&id, (died_at, timer)) in timers.iter_mut() {
 		timer.tick(t.delta());
 		if timer.just_finished() {
-			spawn_events.send(PlayerSpawnEvent {
+			spawn_events.write(PlayerSpawnEvent {
 				id,
 				died_at: *died_at,
 			});
@@ -1158,7 +1160,7 @@ pub fn countdown_respawn(
 
 pub fn kill_on_key(
 	mut cmds: Commands,
-	q: Query<(Entity, &BelongsToPlayer), (Without<NeverDespawn>, Without<Parent>)>,
+	q: Query<(Entity, &BelongsToPlayer), (Without<NeverDespawn>, Without<ChildOf>)>,
 	roots: Query<(&GlobalTransform, &BelongsToPlayer), WithVariant<Root>>,
 	input: Res<ButtonInput<KeyCode>>,
 	mut respawn_timers: ResMut<PlayerRespawnTimers>,
@@ -1166,7 +1168,7 @@ pub fn kill_on_key(
 ) {
 	if input.just_pressed(KeyCode::KeyK) {
 		for (id, owner) in &q {
-			cmds.entity(id).despawn_recursive();
+			cmds.entity(id).despawn();
 			roots.iter().find_map(|(global, id)| {
 				(*id == *owner).then(|| {
 					respawn_timers

--- a/rs/src/player/abilities.rs
+++ b/rs/src/player/abilities.rs
@@ -6,8 +6,7 @@ use bevy_kira_audio::{Audio, AudioControl, AudioSource};
 use bevy_rapier3d::{
 	geometry::CollisionGroups,
 	pipeline::QueryFilter,
-	plugin::RapierContext,
-	prelude::{Collider, ShapeCastHit, ShapeCastOptions},
+	prelude::{Collider, ReadRapierContext, ShapeCastHit, ShapeCastOptions},
 };
 use enum_components::{ERef, WithVariant};
 use leafwing_input_manager::{action_state::ActionState, systems::update_action_state};
@@ -536,7 +535,7 @@ pub struct Hurt {
 }
 
 pub fn hit_stuff(
-	ctx: Single<&RapierContext>,
+	ctx: ReadRapierContext,
 	q: Query<
 		(
 			Entity,
@@ -549,6 +548,9 @@ pub fn hit_stuff(
 	>,
 	mut events: EventWriter<Hurt>,
 ) {
+	let Ok(ctx) = ctx.single() else {
+		return;
+	};
 	for (id, xform, prev, col, filter) in &q {
 		let xform = xform.compute_transform();
 		let prev = prev.compute_transform();
@@ -570,7 +572,7 @@ pub fn hit_stuff(
 		) else {
 			continue;
 		};
-		events.send(Hurt {
+		events.write(Hurt {
 			hurtbox: id,
 			hit: toi,
 			victim: other,

--- a/rs/src/player/camera.rs
+++ b/rs/src/player/camera.rs
@@ -30,8 +30,7 @@ use bevy_rapier3d::{
 	geometry::{Collider, CollisionGroups, Group},
 	math::Vect,
 	pipeline::QueryFilter,
-	plugin::RapierContext,
-	prelude::ShapeCastOptions,
+	prelude::{ReadRapierContext, ShapeCastOptions},
 };
 use engine::ui::spawn_ui_camera;
 use enum_components::{ERef, EntityEnumCommands, WithVariant};
@@ -97,12 +96,14 @@ pub fn spawn_cameras(
 		diffuse.resize(size);
 
 		#[cfg(feature = "debugging")]
-		for chunk in tex.data.chunks_mut(16) {
-			// Displays fuchsia if shader/custom pipeline aren't working
-			chunk.copy_from_slice(unsafe {
-				&*(&bevy::color::palettes::basic::FUCHSIA.to_f32_array() as *const [f32; 4]
-					as *const [u8; 16])
-			});
+		if let Some(data) = tex.data.as_mut() {
+			for chunk in data.chunks_mut(16) {
+				// Displays fuchsia if shader/custom pipeline aren't working
+				chunk.copy_from_slice(unsafe {
+					&*(&bevy::color::palettes::basic::FUCHSIA.to_f32_array() as *const [f32; 4]
+						as *const [u8; 16])
+				});
+			}
 		}
 
 		tex.reinterpret_stacked_2d_as_array(6);
@@ -157,6 +158,7 @@ pub fn spawn_cameras(
 				specular_map: sky_texture.clone(),
 				intensity: 1_000.0,
 				rotation: Quat::from_rotation_x(FRAC_PI_2),
+				affects_lightmapped_mesh_diffuse: true,
 			},
 			Bloom {
 				intensity: 0.2,
@@ -209,10 +211,13 @@ pub fn spawn_pivot<'a>(
 pub struct CamTarget(pub Transform);
 
 pub fn position_target(
-	ctx: Single<&RapierContext>,
+	ctx: ReadRapierContext,
 	cam_pivot_q: Query<(&GlobalTransform, &BelongsToPlayer), WithVariant<CamPivot>>,
 	mut cam_q: Query<(&mut CamTarget, &Collider, &BelongsToPlayer, ERef<Cam>)>,
 ) {
+	let Ok(ctx) = ctx.single() else {
+		return;
+	};
 	for (mut target, col, cam_owner, cam) in &mut cam_q {
 		let Some(pivot_xform) = cam_pivot_q
 			.iter()
@@ -289,7 +294,7 @@ pub fn follow_target(
 			continue;
 		};
 		let new = cam_xform.sl_decay(**target_xform, *smoothing, dt);
-		sender.send(ComponentDelta::<Transform>::default_diffable(id, new));
+		sender.write(ComponentDelta::<Transform>::default_diffable(id, new));
 	}
 }
 

--- a/rs/src/player/ctrl.rs
+++ b/rs/src/player/ctrl.rs
@@ -48,7 +48,7 @@ pub struct CtrlVel {
 }
 
 pub fn antigrav(
-	mut ctx: Mut<RapierContext>,
+	ctx: &mut RapierContextMut,
 	body_id: Entity,
 	global: &Transform,
 	col: &Collider,
@@ -97,11 +97,15 @@ pub fn antigrav(
 			error!(?id, "body hit by antigrav missing from ctx.entity2body");
 			return;
 		};
-		ctx.bodies.get_mut(body).unwrap().apply_impulse_at_point(
-			Vector3::from(global.rotation * details.normal2) * x0 * 100.0,
-			details.witness1.into(),
-			true,
-		);
+		ctx.rigidbody_set
+			.bodies
+			.get_mut(body)
+			.unwrap()
+			.apply_impulse_at_point(
+				Vector3::from(global.rotation * details.normal2) * x0 * 100.0,
+				details.witness1.into(),
+				true,
+			);
 		if angle < params.phys.slide_angle.rad() {
 			ctrl_state.touching_ground = true;
 
@@ -186,7 +190,7 @@ pub fn gravity(mut q: Query<(&mut CtrlVel, &CtrlState)>, params: Res<PlayerParam
 }
 
 pub fn move_player(
-	mut ctx: Single<&mut RapierContext>,
+	mut ctx: WriteRapierContext,
 	heightfield_filter: OneWayHeightFieldFilter,
 	mut body_q: Query<(Entity, &mut Transform, &BelongsToPlayer), WithVariant<Root>>,
 	mut ctrl_q: Query<
@@ -215,6 +219,9 @@ pub fn move_player(
 	mut contacts: Local<Vec<(Vec3, f32)>>,
 ) {
 	use engine::DT;
+	let Ok(mut ctx) = ctx.single_mut() else {
+		return;
+	};
 	// Rapier adds t.delta_secs() at the beginning of the simulation step, but we need to know what
 	// it is before that happens, while still matching the behavior of other interpolated bodies.
 	let mut diff = sim_to_render.diff + t.delta_secs();
@@ -272,7 +279,7 @@ pub fn move_player(
 				}
 
 				antigrav(
-					ctx.reborrow(),
+					&mut ctx,
 					body_id,
 					&body_xform,
 					col,
@@ -382,10 +389,10 @@ pub fn move_player(
 							if handle == col_id {
 								return true;
 							}
-							let Some(handle) = ctx.entity2collider().get(&handle) else {
+							let Some(handle) = ctx.colliders.entity2collider().get(&handle) else {
 								return true;
 							};
-							if let Some(other_col) = ctx.colliders.get(*handle) {
+							if let Some(other_col) = ctx.colliders.colliders.get(*handle) {
 								manifolds.clear();
 								let rel = iso.inv_mul(other_col.position());
 								if q.contact_manifolds(

--- a/rs/src/ui/dbg_ui.rs
+++ b/rs/src/ui/dbg_ui.rs
@@ -1,5 +1,5 @@
 use bevy::{
-	ecs::{query::QueryFilter, schedule::SystemConfigs},
+	ecs::{query::QueryFilter, schedule::IntoScheduleConfigs, system::ScheduleSystem},
 	prelude::*,
 	window::PrimaryWindow,
 };
@@ -33,11 +33,13 @@ impl Plugin for DbgUiPlugin {
 
 pub fn plot_res_history<T: Resource, const LINES: usize>(
 	map_fn: impl FnMut((usize, &T)) -> (f64, [f64; LINES]) + Clone + Send + Sync + 'static,
-) -> SystemConfigs {
+) -> impl IntoScheduleConfigs<ScheduleSystem, ()> {
 	(move |mut egui_contexts: Query<&mut EguiContext, With<PrimaryWindow>>,
 	       mut ui_hovered: ResMut<UiHovered>,
 	       history: Res<History<T>>| {
-		let mut ctx = egui_contexts.single_mut();
+		let Ok(mut ctx) = egui_contexts.single_mut() else {
+			return;
+		};
 		let ctx = ctx.get_mut();
 		let map_fn = map_fn.clone();
 		egui::Window::new(std::any::type_name::<T>().split("::").last().unwrap())
@@ -55,12 +57,14 @@ pub fn plot_res_history<T: Resource, const LINES: usize>(
 
 pub fn plot_component_history<T: Component, Filter: QueryFilter + 'static, const LINES: usize>(
 	map_fn: impl FnMut((usize, &T)) -> (f64, [f64; LINES]) + Clone + Send + Sync + 'static,
-) -> SystemConfigs {
+) -> impl IntoScheduleConfigs<ScheduleSystem, ()> {
 	(move |mut egui_contexts: Query<&mut EguiContext, With<PrimaryWindow>>,
 	       mut ui_hovered: ResMut<UiHovered>,
 	       q: Query<(Entity, &History<T>), Filter>| {
 		let mut hovered = false;
-		let mut ctx = egui_contexts.single_mut();
+		let Ok(mut ctx) = egui_contexts.single_mut() else {
+			return;
+		};
 		let ctx = ctx.get_mut();
 		for (id, history) in &q {
 			let map_fn = map_fn.clone();
@@ -111,7 +115,9 @@ pub fn height_under_player(
 	frame: Res<Frame>,
 	loaded_chunks: Res<LoadedChunks>,
 ) {
-	let mut ctx = egui_contexts.single_mut();
+	let Ok(mut ctx) = egui_contexts.single_mut() else {
+		return;
+	};
 	let ctx = ctx.get_mut();
 	ctx.style_mut(|style| {
 		style.visuals.window_fill = Color32::from_black_alpha(128);

--- a/rs/src/ui/pause_menu.rs
+++ b/rs/src/ui/pause_menu.rs
@@ -178,15 +178,21 @@ pub fn setup(mut cmds: Commands, mut mats: ResMut<Assets<UiMat>>, ui_fonts: Res<
 						=> |cmds| {
 							cmds
 								.insert(InteractHandlers::on_ok(move |cmds: &mut EntityCommands| {
-									cmds.commands().queue(|world: &mut World| {
-										let mut q = world.query_filtered::<Entity, With<PrefsMenu>>();
-										let panel_id = q.single(world);
-										world.entity_mut(panel_id).fade_in_secs(0.5);
-										let top_menu = MenuRef::new(panel_id);
-										let mut q = world.query_filtered::<&mut MenuStack, With<GlobalUi>>();
-										let mut stack = q.single_mut(world);
-										stack.push(top_menu);
-									});
+								cmds.commands().queue(|world: &mut World| {
+									let mut q = world.query_filtered::<Entity, With<PrefsMenu>>();
+									let Ok(panel_id) = q.single(world) else {
+										error!("failed to find prefs panel");
+										return;
+									};
+									world.entity_mut(panel_id).fade_in_secs(0.5);
+									let top_menu = MenuRef::new(panel_id);
+									let mut q = world.query_filtered::<&mut MenuStack, With<GlobalUi>>();
+									let Ok(mut stack) = q.single_mut(world) else {
+										error!("failed to find global menu stack");
+										return;
+									};
+									stack.push(top_menu);
+								});
 									ControlFlow::Break(())
 								}));
 							focus_state_emissive_observer_setup(cmds, LinearRgba::from(TEAL) * 4.0, LinearRgba::from(TEAL) * 6.0);
@@ -225,15 +231,21 @@ pub fn setup(mut cmds: Commands, mut mats: ResMut<Assets<UiMat>>, ui_fonts: Res<
 						=> |cmds| {
 							cmds
 								.insert(InteractHandlers::on_ok(move |cmds: &mut EntityCommands| {
-									cmds.commands().queue(|world: &mut World| {
-										let mut q = world.query_filtered::<Entity, With<SettingsMenu>>();
-										let panel_id = q.single(world);
-										world.entity_mut(panel_id).fade_in_secs(0.5);
-										let top_menu = world.resource::<SettingsSubMenus>().top;
-										let mut q = world.query_filtered::<&mut MenuStack, With<GlobalUi>>();
-										let mut stack = q.single_mut(world);
-										stack.push(top_menu);
-									});
+								cmds.commands().queue(|world: &mut World| {
+									let mut q = world.query_filtered::<Entity, With<SettingsMenu>>();
+									let Ok(panel_id) = q.single(world) else {
+										error!("failed to find settings panel");
+										return;
+									};
+									world.entity_mut(panel_id).fade_in_secs(0.5);
+									let top_menu = world.resource::<SettingsSubMenus>().top;
+									let mut q = world.query_filtered::<&mut MenuStack, With<GlobalUi>>();
+									let Ok(mut stack) = q.single_mut(world) else {
+										error!("failed to find global menu stack");
+										return;
+									};
+									stack.push(top_menu);
+								});
 									ControlFlow::Break(())
 								}));
 							focus_state_colors_observer_setup(cmds, Color::BLACK, Color::from(GRAY));
@@ -341,18 +353,28 @@ pub fn pause(
 	mut states: ResMut<StateStack<InputState>>,
 	mut windows: Query<&mut Window>,
 ) {
-	let Ok(mut window) = windows.get_single_mut() else {
+	let Ok(mut window) = windows.single_mut() else {
 		// probably exiting if window is missing
 		return;
 	};
 
-	let id = panel.single();
-	let mut stack = stack.single_mut();
+	let Ok(id) = panel.single() else {
+		error!("missing pause menu panel");
+		return;
+	};
+	let Ok(focus) = resume_btn.single() else {
+		error!("missing resume button");
+		return;
+	};
+	let Ok(mut stack) = stack.single_mut() else {
+		error!("missing global menu stack");
+		return;
+	};
 	if states.last() == Some(&InputState::InGame) {
 		cmds.entity(id).fade_in_secs(0.5);
 		states.push(InputState::InMenu);
 		stack.push(MenuRef {
-			focus: resume_btn.single(),
+			focus,
 			..MenuRef::new(id)
 		});
 		window.cursor_options.visible = true;
@@ -369,12 +391,18 @@ pub fn unpause(
 	mut states: ResMut<StateStack<InputState>>,
 	mut windows: Query<&mut Window>,
 ) {
-	let Ok(mut window) = windows.get_single_mut() else {
+	let Ok(mut window) = windows.single_mut() else {
 		// probably exiting if window is missing
 		return;
 	};
-	let id = panel.single();
-	let mut stack = stack.single_mut();
+	let Ok(id) = panel.single() else {
+		error!("missing pause menu panel");
+		return;
+	};
+	let Ok(mut stack) = stack.single_mut() else {
+		error!("missing global menu stack");
+		return;
+	};
 	if stack.last().map(|menu| menu.root) == Some(id) {
 		debug_assert_eq!(states.last(), Some(&InputState::InMenu));
 		cmds.entity(id).fade_out_secs(0.5);

--- a/rs/src/ui/settings_menu.rs
+++ b/rs/src/ui/settings_menu.rs
@@ -286,12 +286,16 @@ pub fn setup(
 							cmds
 								.observe(focus_toggle_border_observer)
 								.insert(InteractHandlers::on_ok(|cmds: &mut EntityCommands| {
-									cmds.commands().queue(|world: &mut World| {
-										let menu = world.resource::<SettingsSubMenus>().controls;
-										let mut q = world.query_filtered::<&mut MenuStack, With<GlobalUi>>();
-										q.single_mut(world).push(menu);
-										world.entity_mut(menu.root).fade_in_secs(0.5);
-									});
+								cmds.commands().queue(|world: &mut World| {
+									let menu = world.resource::<SettingsSubMenus>().controls;
+									let mut q = world.query_filtered::<&mut MenuStack, With<GlobalUi>>();
+									let Ok(mut stack) = q.single_mut(world) else {
+										error!("failed to find global menu stack");
+										return;
+									};
+									stack.push(menu);
+									world.entity_mut(menu.root).fade_in_secs(0.5);
+								});
 									ControlFlow::Break(())
 								}));
 						}

--- a/rs/src/ui/settings_menu/ctrls_menu.rs
+++ b/rs/src/ui/settings_menu/ctrls_menu.rs
@@ -400,7 +400,10 @@ pub fn anchor_follow_focus(
 	mut stack: Query<&mut MenuStack, With<GlobalUi>>,
 	t: Res<Time>,
 ) {
-	let mut stack = stack.single_mut();
+	let Ok(mut stack) = stack.single_mut() else {
+		error!("missing global menu stack");
+		return;
+	};
 	let Some(menu) = stack.last_mut() else {
 		return;
 	};
@@ -440,6 +443,7 @@ pub fn anchor_follow_focus(
 pub fn update_binding_list_widgets<A: Actionlike + std::fmt::Debug + Serialize>(
 	mut cmds: Commands,
 	q: Query<(Entity, &BindingListContainer<A>, Option<&BelongsToPlayer>)>,
+	children_q: Query<&Children>,
 	imaps: Query<(Ref<InputMap<A>>, &BelongsToPlayer)>,
 	gamepads: Query<(Option<&Name>, &Gamepad)>,
 	mut global_imap: Option<ResMut<InputMap<A>>>,
@@ -472,10 +476,13 @@ pub fn update_binding_list_widgets<A: Actionlike + std::fmt::Debug + Serialize>(
 				.map(Name::as_str)
 				.and_then(Platform::guess_gamepad);
 			let action = &container.0;
-			let mut cmds = cmds.entity(id);
 			debug!(?id, "clearing icons for {action:?}");
-			cmds.despawn_descendants();
-			cmds.with_children(|cmds| {
+			if let Ok(children) = children_q.get(id) {
+				for &child in children {
+					cmds.entity(child).despawn();
+				}
+			}
+			cmds.entity(id).with_children(|cmds| {
 				let outline_mat = text_mat.clone();
 
 				const OUTLINE: MeshOutline = MeshOutline::front_facing(0.1, 0.01);
@@ -503,7 +510,7 @@ pub fn update_binding_list_widgets<A: Actionlike + std::fmt::Debug + Serialize>(
 					}
 
 					fn separator(
-						cmds: &mut ChildBuilder,
+						cmds: &mut bevy::ecs::hierarchy::ChildSpawnerCommands<'_>,
 						text: impl Into<Cow<'static, str>>,
 						scale: f32,
 						font: Handle<Font>,
@@ -527,7 +534,7 @@ pub fn update_binding_list_widgets<A: Actionlike + std::fmt::Debug + Serialize>(
 					}
 
 					fn basic_icons(
-						cmds: &mut ChildBuilder,
+						cmds: &mut bevy::ecs::hierarchy::ChildSpawnerCommands<'_>,
 						icons: ButtonIcons,
 						scale: f32,
 						font: &Handle<Font>,
@@ -609,7 +616,7 @@ pub fn update_binding_list_widgets<A: Actionlike + std::fmt::Debug + Serialize>(
 					}
 
 					fn axis_icons(
-						cmds: &mut ChildBuilder,
+						cmds: &mut bevy::ecs::hierarchy::ChildSpawnerCommands<'_>,
 						icons: AxisIcons,
 						scale: f32,
 						font: &Handle<Font>,
@@ -678,7 +685,7 @@ pub fn update_binding_list_widgets<A: Actionlike + std::fmt::Debug + Serialize>(
 					}
 
 					fn dual_axis_icons(
-						cmds: &mut ChildBuilder,
+						cmds: &mut bevy::ecs::hierarchy::ChildSpawnerCommands<'_>,
 						icons: DualAxisIcons,
 						scale: f32,
 						font: &Handle<Font>,


### PR DESCRIPTION
Partially switched to observers for UI events, but some `InteractionHandler`s were more complex and didn't map cleanly to the observer pattern.